### PR TITLE
Use base image with a JDK

### DIFF
--- a/java-runtime-builder-docker/src/main/resources/docker/Dockerfile
+++ b/java-runtime-builder-docker/src/main/resources/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/google-appengine/openjdk
+FROM openjdk:8-jdk
 
 # install utilities
 RUN apt-get -q update \


### PR DESCRIPTION
The openjdk runtime doesn't work as a base image for the builder since it doesn't contain a JDK.