### PR TITLE
Changes for release

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -5,7 +5,7 @@ This document contains instructions on how to build and test this pipeline.
 ## Local Build
 To build all images for this pipeline locally, you need docker and maven installed. Running 
 `mvn install` will compile all java sources and build all docker images. After the build is complete, 
-resulting images will be present in your local docker repository.
+all resulting images will be present in your local docker repository.
 
 ## Cloud Build
 Google Cloud Container Builder can also be used to build images in the pipeline. The 
@@ -13,7 +13,7 @@ Google Cloud Container Builder can also be used to build images in the pipeline.
 Cloud Container Builder. We provide a script to make it easy to build using Container Builder:
 
 ```bash
-# the following commands will build and push an image named "gcr.io/my-gcp-project/java-runtime-builder:tag"
+# the following commands will build and push an image named "gcr.io/my-gcp-project/runtime-builder:tag"
 PROJECT_ID=my-gcp-project
 TAG_NAME=tag
 ./scripts/build.sh gcr.io/$PROJECT_ID $TAG
@@ -25,7 +25,7 @@ commands effectively mirror the steps in the [java.yaml](java.yaml) pipeline con
 
 ```bash
 # compile my application's source and generate a dockerfile
-docker run -v /path/to/my/java/app:/workspace -w /workspace java-runtime-builder \
+docker run -v /path/to/my/java/app:/workspace -w /workspace runtime-builder \
     --jar-runtime=gcr.io/google-appengine/openjdk \
     --server-runtime=gcr.io/google-appengine/jetty
     

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -15,20 +15,6 @@ Cloud Container Builder. We provide a script to make it easy to build using Cont
 ```bash
 # the following commands will build and push an image named "gcr.io/my-gcp-project/runtime-builder:tag"
 PROJECT_ID=my-gcp-project
-TAG_NAME=tag
+TAG=tag
 ./scripts/build.sh gcr.io/$PROJECT_ID $TAG
-```
-
-## Running locally-built images
-Locally assembled build steps can be run locally, one at a time, using docker. Note that these
-commands effectively mirror the steps in the [java.yaml](java.yaml) pipeline config file.
-
-```bash
-# compile my application's source and generate a dockerfile
-docker run -v /path/to/my/java/app:/workspace -w /workspace runtime-builder \
-    --jar-runtime=gcr.io/google-appengine/openjdk \
-    --server-runtime=gcr.io/google-appengine/jetty
-    
-# package my application into a docker container
-docker build -t my-java-app /path/to/my/java/app/.docker_staging
 ```

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,21 @@
+# Developing
+
+This document contains instructions on how to build and test this pipeline.
+
+## Building
+To build all images for this pipeline, you need docker and maven installed. Running `mvn install`
+will compile all java sources and build all docker images. After the build is complete, the 
+resulting image will be called `java-runtime-builder`.
+
+## Running locally-built images
+Locally assembled build steps can be run locally, one at a time, using docker:
+
+```bash
+# compile my application's source and generate a dockerfile
+docker run -v /path/to/my/java/app:/workspace -w /workspace java-runtime-builder \
+    --jar-runtime=gcr.io/google-appengine/openjdk \
+    --server-runtime=gcr.io/google-appengine/jetty
+    
+# package my application into a docker container
+docker build -t my-java-app /path/to/my/java/app/.docker_staging
+```

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -2,13 +2,26 @@
 
 This document contains instructions on how to build and test this pipeline.
 
-## Building
-To build all images for this pipeline, you need docker and maven installed. Running `mvn install`
-will compile all java sources and build all docker images. After the build is complete, the 
-resulting image will be called `java-runtime-builder`.
+## Local Build
+To build all images for this pipeline locally, you need docker and maven installed. Running 
+`mvn install` will compile all java sources and build all docker images. After the build is complete, 
+resulting images will be present in your local docker repository.
+
+## Cloud Build
+Google Cloud Container Builder can also be used to build images in the pipeline. The 
+[Google Cloud SDK](https://cloud.google.com/sdk/) must be installed locally in order to use Google
+Cloud Container Builder. We provide a script to make it easy to build using Container Builder:
+
+```bash
+# the following commands will build and push an image named "gcr.io/my-gcp-project/java-runtime-builder:tag"
+PROJECT_ID=my-gcp-project
+TAG_NAME=tag
+./scripts/build.sh gcr.io/$PROJECT_ID $TAG
+```
 
 ## Running locally-built images
-Locally assembled build steps can be run locally, one at a time, using docker:
+Locally assembled build steps can be run locally, one at a time, using docker. Note that these
+commands effectively mirror the steps in the [java.yaml](java.yaml) pipeline config file.
 
 ```bash
 # compile my application's source and generate a dockerfile

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 
 A [Google Cloud Container Builder](https://cloud.google.com/container-builder/docs/) pipeline for 
 packaging Java applications into supported Google Cloud Runtime containers. It consists of a series
-of docker containers, used as build steps, and a [cloudbuild.yaml](cloudbuild.yaml) configuration 
-file.
+of docker containers, used as build steps, and a build pipeline configuration file.
 
 ## Building Locally
 The pipeline can be built using maven:
@@ -17,39 +16,19 @@ mvn clean install
 ## Running via Google Cloud Container Builder (recommended)
 To run via Google Cloud Container Builder, first install the
 [Google Cloud SDK](https://cloud.google.com/sdk/). Then, initiate a Cloud Container Build using the 
-provided [cloudbuild.yaml](cloudbuild.yaml) file:
+provided [java.yaml](java.yaml) file:
 ```bash
-# first, build locally using maven
-mvn clean install
+# Determine the name of your desired output image. Note that it must be a path to a Google Container
+# Registry bucket to which your Cloud SDK installation has push access.
+OUTPUT_IMAGE=gcr.io/my-gcp-project/my-application-container
 
-# then, push built images to GCR
-GCP_PROJECT_ID=my-project-id
-docker tag java-runtime-builder gcr.io/$GCP_PROJECT_ID/java-runtime-builder
-gcloud docker -- push gcr.io/$GCP_PROJECT_ID/java-runtime-builder
-
-# finally, initiate the cloud container build
+# initiate the cloud container build
 gcloud container builds submit /path/to/my/java/app \ 
-    --config cloudbuild.yaml \
-    --substitutions _OUTPUT_IMAGE=gcr.io/$GCP_PROJECT_ID/my-application-container
+    --config java.yaml \
+    --substitutions _OUTPUT_IMAGE=$OUTPUT_IMAGE
 ```
 After the build completes, the built application container will appear in the [gcr.io container 
-registry](https://cloud.google.com/container-registry/) for the GCP project configured in the Cloud 
-SDK.
-
-## Running locally
-Locally assembled build steps can also be run locally, one at a time, using docker:
-```bash
-# build locally
-mvn clean install
-
-# compile my application's source and generate a dockerfile
-docker run -v /path/to/my/java/app:/workspace -w /workspace java-runtime-builder \
-    --jar-runtime=gcr.io/google-appengine/openjdk \
-    --server-runtime=gcr.io/google-appengine/jetty
-    
-# package my application into a docker container
-docker build -t my-java-app /path/to/my/java/app/.docker_staging
-```
+registry](https://cloud.google.com/container-registry/) at the specified path.
 
 ## Configuration
 An [app.yaml](https://cloud.google.com/appengine/docs/flexible/java/configuring-your-app-with-app-yaml) 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,7 @@ A [Google Cloud Container Builder](https://cloud.google.com/container-builder/do
 packaging Java applications into supported Google Cloud Runtime containers. It consists of a series
 of docker containers, used as build steps, and a build pipeline configuration file.
 
-## Building Locally
-The pipeline can be built using maven:
-```bash
-mvn clean install
-```
-
-## Running via Google Cloud Container Builder (recommended)
+## Running via Google Cloud Container Builder
 To run via Google Cloud Container Builder, first install the
 [Google Cloud SDK](https://cloud.google.com/sdk/). Then, initiate a Cloud Container Build using the 
 provided [java.yaml](java.yaml) file:
@@ -52,6 +46,8 @@ runtime_config:
   build_script: "mvn clean install -Pcloud-build-profile"
 ```
 
+## Development guide
+* See [DEVELOPING.md](DEVELOPING.md) for instructions on how to build and test this pipeline.
 
 ## Contributing changes
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A [Google Cloud Container Builder](https://cloud.google.com/container-builder/do
 packaging Java applications into supported Google Cloud Runtime containers. It consists of a series
 of docker containers, used as build steps, and a build pipeline configuration file.
 
-## Running via Google Cloud Container Builder
+## Running via Google Cloud Container Builder (recommended)
 To run via Google Cloud Container Builder, first install the
 [Google Cloud SDK](https://cloud.google.com/sdk/). Then, initiate a Cloud Container Build using the 
 provided [java.yaml](java.yaml) file:
@@ -23,6 +23,21 @@ gcloud container builds submit /path/to/my/java/app \
 ```
 After the build completes, the built application container will appear in the [gcr.io container 
 registry](https://cloud.google.com/container-registry/) at the specified path.
+
+## Running via Docker (without Cloud Container Builder)
+Build steps can be run locally, one at a time, using docker. (This requires that the `runtime-builder`
+image is available locally.) Note that these commands effectively mirror the steps in the
+[java.yaml](java.yaml) pipeline config file.
+
+```bash
+# compile my application's source and generate a dockerfile
+docker run -v /path/to/my/java/app:/workspace -w /workspace runtime-builder \
+    --jar-runtime=gcr.io/google-appengine/openjdk \
+    --server-runtime=gcr.io/google-appengine/jetty
+    
+# package my application into a docker container
+docker build -t my-java-app /path/to/my/java/app/.docker_staging
+```
 
 ## Configuration
 An [app.yaml](https://cloud.google.com/appengine/docs/flexible/java/configuring-your-app-with-app-yaml) 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,7 +1,7 @@
 # Java runtime builder pipeline.
 
 steps:
-- name: 'gcr.io/$PROJECT_ID/java-runtime-builder'
+- name: 'gcr.io/gcp-runtimes/java/runtime-builder'
   args: ['--server-runtime', 'gcr.io/google_appengine/jetty:latest',
   '--jar-runtime', 'gcr.io/google_appengine/openjdk:latest']
 - name: 'gcr.io/cloud-builders/docker'

--- a/java-runtime-builder-docker/pom.xml
+++ b/java-runtime-builder-docker/pom.xml
@@ -17,6 +17,45 @@
     <runtime.builder.artifact>java-runtime-builder.jar</runtime.builder.artifact>
   </properties>
 
+  <profiles>
+    <profile>
+      <id>local-docker-build</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>io.fabric8</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+            <version>0.20.0</version>
+            <configuration>
+              <verbose>true</verbose>
+              <autoPull>always</autoPull>
+              <images>
+                <image>
+                  <name>java-runtime-builder</name>
+                  <build>
+                    <dockerFileDir>${project.build.outputDirectory}/docker</dockerFileDir>
+                    <nocache>true</nocache>
+                  </build>
+                </image>
+              </images>
+            </configuration>
+            <executions>
+              <execution>
+                <id>docker-build</id>
+                <goals>
+                  <goal>build</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
   <build>
     <resources>
       <resource>
@@ -47,32 +86,6 @@
                 </artifactItem>
               </artifactItems>
             </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>io.fabric8</groupId>
-        <artifactId>docker-maven-plugin</artifactId>
-        <version>0.20.0</version>
-        <configuration>
-          <verbose>true</verbose>
-          <autoPull>always</autoPull>
-          <images>
-            <image>
-              <name>java-runtime-builder</name>
-              <build>
-                <dockerFileDir>${project.build.outputDirectory}/docker</dockerFileDir>
-                <nocache>true</nocache>
-              </build>
-            </image>
-          </images>
-        </configuration>
-        <executions>
-          <execution>
-            <id>docker-build</id>
-            <goals>
-              <goal>build</goal>
-            </goals>
           </execution>
         </executions>
       </plugin>

--- a/java-runtime-builder-docker/pom.xml
+++ b/java-runtime-builder-docker/pom.xml
@@ -34,7 +34,7 @@
               <autoPull>always</autoPull>
               <images>
                 <image>
-                  <name>java-runtime-builder</name>
+                  <name>runtime-builder</name>
                   <build>
                     <dockerFileDir>${project.build.outputDirectory}/docker</dockerFileDir>
                     <nocache>true</nocache>

--- a/java.yaml
+++ b/java.yaml
@@ -1,10 +1,14 @@
 # Java runtime builder pipeline.
 
 steps:
-- name: 'gcr.io/gcp-runtimes/java/runtime-builder'
+
+# build the user's source and generate artifacts for docker
+- name: 'gcr.io/gcp-runtimes/java/runtime-builder:latest'
   args: ['--server-runtime', 'gcr.io/google_appengine/jetty:latest',
   '--jar-runtime', 'gcr.io/google_appengine/openjdk:latest']
-- name: 'gcr.io/cloud-builders/docker'
+
+# execute the docker build to produce the resulting image
+- name: 'gcr.io/cloud-builders/docker:latest'
   args: ['build', '--tag=$_OUTPUT_IMAGE', '.docker_staging']
 
 images: ['$_OUTPUT_IMAGE']

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+# Copyright 2016 Google Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+dir=$(dirname $0)
+projectRoot=$dir/..
+
+RUNTIME_NAME="java-runtime-builder"
+DOCKER_NAMESPACE=$1
+DOCKER_TAG=$2
+
+if [ -z "${DOCKER_NAMESPACE}" ]; then
+  echo "Usage: ${0} <docker_namespace> <docker_tag>"
+  exit 1
+fi
+
+if [ -z "${DOCKER_TAG}" ]; then
+  DOCKER_TAG=$(date +%Y-%m-%d-%H_%M_%S)
+fi
+
+IMAGE="${DOCKER_NAMESPACE}/${RUNTIME_NAME}:${DOCKER_TAG}"
+echo "IMAGE: $IMAGE"
+
+# build and test the runtime image
+gcloud container builds submit \
+  --config=$dir/pipeline-cloudbuild.yaml \
+  --substitutions="_IMAGE=$IMAGE" \
+  $projectRoot

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -19,7 +19,7 @@ set -e
 dir=$(dirname $0)
 projectRoot=$dir/..
 
-RUNTIME_NAME="java-runtime-builder"
+RUNTIME_NAME="runtime-builder"
 DOCKER_NAMESPACE=$1
 DOCKER_TAG=$2
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -24,7 +24,7 @@ DOCKER_NAMESPACE=$1
 DOCKER_TAG=$2
 
 if [ -z "${DOCKER_NAMESPACE}" ]; then
-  echo "Usage: ${0} <docker_namespace> <docker_tag>"
+  echo "Usage: ${0} <docker_namespace> [docker_tag]"
   exit 1
 fi
 

--- a/scripts/ci-build.sh
+++ b/scripts/ci-build.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# Copyright 2016 Google Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+dir=$(dirname $0)
+
+echo "Invoking build.sh with DOCKER_NAMESPACE=$DOCKER_NAMESPACE, TAG=$TAG"
+$dir/build.sh $DOCKER_NAMESPACE $TAG

--- a/scripts/pipeline-cloudbuild.yaml
+++ b/scripts/pipeline-cloudbuild.yaml
@@ -1,0 +1,20 @@
+# Cloud container builder pipeline for building all docker images for the the Java Runtime Builder.
+# https://cloud.google.com/container-builder/docs/overview
+
+steps:
+# Build the maven project, omitting the docker build step
+- name: 'maven:3.3.9-jdk-8'
+  args: ['mvn', '-P-local-docker-build', 'clean', 'install']
+  id: 'MAVEN'
+# Execute the docker build
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--tag=${_IMAGE}', '--no-cache', 'java-runtime-builder-docker/target/classes/docker']
+  id: 'DOCKER'
+
+# Runtimes-common structure tests
+# See https://github.com/GoogleCloudPlatform/runtimes-common/tree/master/structure_tests
+#- name: 'gcr.io/gcp-runtimes/structure_test'
+#  args: ['--image', '${_IMAGE}', '-v', '--config', '/workspace/openjdk8/target/test-classes/structure.yaml']
+#  id: 'STRUCTURE_TEST'
+
+images: ['${_IMAGE}']


### PR DESCRIPTION
This PR contains changes needed to perform release builds of the images in the builder pipeline. Notably:
* added various scripts in the `scripts` directory build with cloud container builder.
* renamed the pipeline config file from `cloudbuild.yaml` to `java.yaml`
* updated the runtime builder container's coordinates from `gcr.io/$PROJECT_ID/java-runtime-builder` to `gcr.io/gcp-runtimes/java/runtime-builder`
* documentation updates