### PR TITLE
Maven/Gradle build failures stop execution immediately

### DIFF
--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/buildsteps/base/BuildStepException.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/buildsteps/base/BuildStepException.java
@@ -22,4 +22,8 @@ public class BuildStepException extends Exception {
     super(throwable);
   }
 
+  public BuildStepException(String message) {
+    super(message);
+  }
+
 }

--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/buildsteps/gradle/GradleBuildStep.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/buildsteps/gradle/GradleBuildStep.java
@@ -40,11 +40,16 @@ public class GradleBuildStep extends BuildStep {
   @Override
   protected void doBuild(Path directory, Map<String, String> metadata) throws BuildStepException {
     try {
-      new ProcessBuilder()
+      int exitCode = new ProcessBuilder()
           .command(getGradleExecutable(directory), "build")
           .directory(directory.toFile())
           .inheritIO()
           .start().waitFor();
+
+      if (exitCode != 0) {
+        throw new BuildStepException(
+            String.format("Child process exited with non-zero exit code: %s", exitCode));
+      }
 
       metadata.put(BuildStepMetadataConstants.BUILD_ARTIFACT_PATH, "build/libs");
 

--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/buildsteps/maven/MavenBuildStep.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/buildsteps/maven/MavenBuildStep.java
@@ -30,6 +30,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
 
+/**
+ * Build step that invokes maven.
+ */
 public class MavenBuildStep extends BuildStep {
 
   private static final Logger logger = LoggerFactory.getLogger(MavenBuildStep.class);
@@ -37,11 +40,16 @@ public class MavenBuildStep extends BuildStep {
   @Override
   protected void doBuild(Path directory, Map<String, String> metadata) throws BuildStepException {
     try {
-      new ProcessBuilder()
+      int exitCode = new ProcessBuilder()
           .command(getMavenExecutable(directory), "-B", "-DskipTests=true", "clean", "package")
           .directory(directory.toFile())
           .inheritIO()
           .start().waitFor();
+
+      if (exitCode != 0) {
+        throw new BuildStepException(
+            String.format("Child process exited with non-zero exit code: %s", exitCode));
+      }
 
       metadata.put(BuildStepMetadataConstants.BUILD_ARTIFACT_PATH, "target/");
 


### PR DESCRIPTION
fixes https://github.com/GoogleCloudPlatform/runtime-builder-java/issues/15

If the maven or gradle child processes exit with a nonzero exit code, throw an exception.