### PR TITLE
Codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,10 @@
+comment: off
+notify: false
+coverage:
+  status:
+    project:
+      default: false
+      java-runtime-builder-app:
+        paths: "java-runtime-builder-app/"
+        target: auto
+        base: auto

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,14 +1,11 @@
-comment: off
-notify: false
 coverage:
+
   status:
     project:
-      default: false
-      java-runtime-builder-app:
-        paths: "java-runtime-builder-app/"
-        target: auto
-        base: auto
-    patch:
-      default:
-        target: auto
-        base: auto
+     default: off
+     runtime_builder_app:
+       paths: "java-runtime-builder-app/"
+    patch: true
+    changes: false
+
+comment: off

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,3 +8,7 @@ coverage:
         paths: "java-runtime-builder-app/"
         target: auto
         base: auto
+    patch:
+      default:
+        target: auto
+        base: auto

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ jdk:
 
 script: mvn --batch-mode clean package
 
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
+
 branches:
   only:
   - master

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Java Runtime Builder
 
-[![unstable](http://badges.github.io/stability-badges/dist/unstable.svg)](http://github.com/badges/stability-badges)
 [![Build Status](https://travis-ci.org/GoogleCloudPlatform/runtime-builder-java.svg?branch=master)](https://travis-ci.org/GoogleCloudPlatform/runtime-builder-java)
+[![codecov](https://codecov.io/gh/GoogleCloudPlatform/runtime-builder-java/branch/master/graph/badge.svg)](https://codecov.io/gh/GoogleCloudPlatform/runtime-builder-java)
+[![unstable](http://badges.github.io/stability-badges/dist/unstable.svg)](http://github.com/badges/stability-badges)
 
 A [Google Cloud Container Builder](https://cloud.google.com/container-builder/docs/) pipeline for 
 packaging Java applications into supported Google Cloud Runtime containers. It consists of a series

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.google.cloud.runtimes</groupId>
@@ -93,7 +93,25 @@
           </dependency>
         </dependencies>
       </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.7.7.201606060606</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
-
   </build>
 </project>


### PR DESCRIPTION
Adds codecov support for travis builds. 

By default, a codecov report (see below) is added to PRs via a comment. To reduce noise, I I disabled this feature (see .codecov.yml config), instead favoring commit-level statuses. This way the coverage data is still available, but far less obtrusive.

Note that covdcov.io only reads config files from `master`, so these changes won't go into effect until this PR is merged.