### PR TITLE
Add support for Jetty Quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ section of this file tells the builder how to build and package your source. In 
 |----------|------|---------|-------------|
 | artifact | string |  Discovered based on the content of your build output | The path where the builder should expect to find the artifact to package in the resulting docker container. This setting will be required if your build produces more than one artifact. 
 | build_script | string | `mvn -B -DskipTests clean package` if a maven project is detected, or `gradle build` if a gradle project is detected | The build command that is executed to build your source |
+| jetty_quickstart | boolean | false | Enable the [Jetty quickstart module](http://www.eclipse.org/jetty/documentation/9.4.x/quickstart-webapp.html) to speed up the start time of the application (Only available if the jetty runtime is selected).
 
 ### Sample app.yaml
 ```yaml
@@ -60,6 +61,7 @@ env: flex
 runtime_config:
   artifact: "target/my-artifact.jar"
   build_script: "mvn clean install -Pcloud-build-profile"
+  jetty_quickstart: true
 ```
 
 ## Development guide

--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/BuildPipelineConfigurator.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/BuildPipelineConfigurator.java
@@ -102,6 +102,7 @@ public class BuildPipelineConfigurator {
     StageDockerArtifactBuildStep stageDockerBuildStep
         = buildStepFactory.createStageDockerArtifactBuildStep();
     stageDockerBuildStep.setArtifactPathOverride(runtimeConfig.getArtifact());
+    stageDockerBuildStep.setRuntimeConfig(runtimeConfig);
     steps.add(stageDockerBuildStep);
     return steps;
   }

--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/BuildPipelineConfigurator.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/BuildPipelineConfigurator.java
@@ -100,9 +100,8 @@ public class BuildPipelineConfigurator {
     }
 
     StageDockerArtifactBuildStep stageDockerBuildStep
-        = buildStepFactory.createStageDockerArtifactBuildStep();
+        = buildStepFactory.createStageDockerArtifactBuildStep(runtimeConfig);
     stageDockerBuildStep.setArtifactPathOverride(runtimeConfig.getArtifact());
-    stageDockerBuildStep.setRuntimeConfig(runtimeConfig);
     steps.add(stageDockerBuildStep);
     return steps;
   }

--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/buildsteps/base/BuildStepFactory.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/buildsteps/base/BuildStepFactory.java
@@ -20,6 +20,7 @@ import com.google.cloud.runtimes.builder.buildsteps.GradleBuildStep;
 import com.google.cloud.runtimes.builder.buildsteps.MavenBuildStep;
 import com.google.cloud.runtimes.builder.buildsteps.ScriptExecutionBuildStep;
 import com.google.cloud.runtimes.builder.buildsteps.docker.StageDockerArtifactBuildStep;
+import com.google.cloud.runtimes.builder.config.domain.RuntimeConfig;
 
 /**
  * Factory interface to simplify instantiation of objects with Guice-provided dependencies. See
@@ -32,7 +33,7 @@ public interface BuildStepFactory {
 
   GradleBuildStep createGradleBuildStep();
 
-  StageDockerArtifactBuildStep createStageDockerArtifactBuildStep();
+  StageDockerArtifactBuildStep createStageDockerArtifactBuildStep(RuntimeConfig runtimeConfig);
 
   ScriptExecutionBuildStep createScriptExecutionBuildStep(String buildCommand);
 

--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/buildsteps/docker/DefaultDockerfileGenerator.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/buildsteps/docker/DefaultDockerfileGenerator.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.runtimes.builder.buildsteps.docker;
 
+import com.google.cloud.runtimes.builder.config.domain.RuntimeConfig;
 import com.google.cloud.runtimes.builder.injection.JarRuntimeImage;
 import com.google.cloud.runtimes.builder.injection.ServerRuntimeImage;
 import com.google.common.io.Files;
@@ -45,7 +46,8 @@ public class DefaultDockerfileGenerator implements DockerfileGenerator {
   }
 
   @Override
-  public String generateDockerfile(Path artifactToDeploy) {
+  public String generateDockerfile(Path artifactToDeploy, RuntimeConfig runtimeConfig) {
+    StringBuilder dockerfile = new StringBuilder();
     String fileType = Files.getFileExtension(artifactToDeploy.toString());
     String baseImage;
     String appDest;
@@ -61,7 +63,13 @@ public class DefaultDockerfileGenerator implements DockerfileGenerator {
           String.format("Unable to determine the runtime for artifact %s.",
               artifactToDeploy.getFileName()));
     }
-    return String.format(DOCKERFILE, baseImage, artifactToDeploy.toString(), appDest);
+    dockerfile.append(String.format(DOCKERFILE, baseImage, artifactToDeploy.toString(), appDest));
+
+    if (baseImage.equals(serverRuntime) && runtimeConfig.getJettyQuickstart()) {
+      dockerfile.append("RUN /scripts/jetty/quickstart.sh");
+    }
+
+    return dockerfile.toString();
   }
 
 }

--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/buildsteps/docker/DefaultDockerfileGenerator.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/buildsteps/docker/DefaultDockerfileGenerator.java
@@ -66,7 +66,7 @@ public class DefaultDockerfileGenerator implements DockerfileGenerator {
     dockerfile.append(String.format(DOCKERFILE, baseImage, artifactToDeploy.toString(), appDest));
 
     if (baseImage.equals(serverRuntime) && runtimeConfig.getJettyQuickstart()) {
-      dockerfile.append("RUN /scripts/jetty/quickstart.sh");
+      dockerfile.append("RUN /scripts/jetty/quickstart.sh\n");
     }
 
     return dockerfile.toString();

--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/buildsteps/docker/DockerfileGenerator.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/buildsteps/docker/DockerfileGenerator.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.runtimes.builder.buildsteps.docker;
 
+import com.google.cloud.runtimes.builder.config.domain.RuntimeConfig;
+
 import java.nio.file.Path;
 
 public interface DockerfileGenerator {
@@ -23,6 +25,6 @@ public interface DockerfileGenerator {
   /**
    * Generate a Dockerfile for an artifact file at the given path.
    */
-  String generateDockerfile(Path artifact);
+  String generateDockerfile(Path artifact, RuntimeConfig runtimeConfig);
 
 }

--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/buildsteps/docker/StageDockerArtifactBuildStep.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/buildsteps/docker/StageDockerArtifactBuildStep.java
@@ -24,6 +24,7 @@ import com.google.cloud.runtimes.builder.exception.ArtifactNotFoundException;
 import com.google.cloud.runtimes.builder.exception.TooManyArtifactsException;
 import com.google.inject.Inject;
 
+import com.google.inject.assistedinject.Assisted;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,16 +49,13 @@ public class StageDockerArtifactBuildStep extends BuildStep {
   private RuntimeConfig runtimeConfig;
 
   @Inject
-  StageDockerArtifactBuildStep(DockerfileGenerator dockerfileGenerator) {
+  StageDockerArtifactBuildStep(DockerfileGenerator dockerfileGenerator, @Assisted RuntimeConfig runtimeConfig) {
     this.dockerfileGenerator = dockerfileGenerator;
+    this.runtimeConfig = runtimeConfig;
   }
 
   public void setArtifactPathOverride(String artifactPathOverride) {
     this.artifactPathOverride = artifactPathOverride;
-  }
-
-  public void setRuntimeConfig(RuntimeConfig runtimeConfig) {
-    this.runtimeConfig = runtimeConfig;
   }
 
   @Override
@@ -90,7 +88,7 @@ public class StageDockerArtifactBuildStep extends BuildStep {
 
       // Generate dockerfile
       String dockerfile = dockerfileGenerator.generateDockerfile(artifact.getFileName(),
-                                                                 getRuntimeConfig());
+                                                                 runtimeConfig);
       Path dockerFileDest = stagingDir.resolve("Dockerfile");
 
       try (BufferedWriter writer
@@ -119,14 +117,6 @@ public class StageDockerArtifactBuildStep extends BuildStep {
       // otherwise, search for an artifact in the workspace root
       return searchForArtifactInDir(directory);
     }
-  }
-
-  private RuntimeConfig getRuntimeConfig() {
-    if (this.runtimeConfig == null) {
-      this.runtimeConfig = new RuntimeConfig();
-    }
-
-    return this.runtimeConfig;
   }
 
   /*

--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/buildsteps/docker/StageDockerArtifactBuildStep.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/buildsteps/docker/StageDockerArtifactBuildStep.java
@@ -25,6 +25,7 @@ import com.google.cloud.runtimes.builder.exception.TooManyArtifactsException;
 import com.google.inject.Inject;
 
 import com.google.inject.assistedinject.Assisted;
+
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,7 +50,8 @@ public class StageDockerArtifactBuildStep extends BuildStep {
   private RuntimeConfig runtimeConfig;
 
   @Inject
-  StageDockerArtifactBuildStep(DockerfileGenerator dockerfileGenerator, @Assisted RuntimeConfig runtimeConfig) {
+  StageDockerArtifactBuildStep(DockerfileGenerator dockerfileGenerator,
+                               @Assisted RuntimeConfig runtimeConfig) {
     this.dockerfileGenerator = dockerfileGenerator;
     this.runtimeConfig = runtimeConfig;
   }

--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/buildsteps/docker/StageDockerArtifactBuildStep.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/buildsteps/docker/StageDockerArtifactBuildStep.java
@@ -19,6 +19,7 @@ package com.google.cloud.runtimes.builder.buildsteps.docker;
 import com.google.cloud.runtimes.builder.buildsteps.base.BuildStep;
 import com.google.cloud.runtimes.builder.buildsteps.base.BuildStepException;
 import com.google.cloud.runtimes.builder.buildsteps.base.BuildStepMetadataConstants;
+import com.google.cloud.runtimes.builder.config.domain.RuntimeConfig;
 import com.google.cloud.runtimes.builder.exception.ArtifactNotFoundException;
 import com.google.cloud.runtimes.builder.exception.TooManyArtifactsException;
 import com.google.inject.Inject;
@@ -44,6 +45,7 @@ public class StageDockerArtifactBuildStep extends BuildStep {
   private final Logger logger = LoggerFactory.getLogger(StageDockerArtifactBuildStep.class);
   private final DockerfileGenerator dockerfileGenerator;
   private String artifactPathOverride;
+  private RuntimeConfig runtimeConfig;
 
   @Inject
   StageDockerArtifactBuildStep(DockerfileGenerator dockerfileGenerator) {
@@ -52,6 +54,10 @@ public class StageDockerArtifactBuildStep extends BuildStep {
 
   public void setArtifactPathOverride(String artifactPathOverride) {
     this.artifactPathOverride = artifactPathOverride;
+  }
+
+  public void setRuntimeConfig(RuntimeConfig runtimeConfig) {
+    this.runtimeConfig = runtimeConfig;
   }
 
   @Override
@@ -83,7 +89,8 @@ public class StageDockerArtifactBuildStep extends BuildStep {
       }
 
       // Generate dockerfile
-      String dockerfile = dockerfileGenerator.generateDockerfile(artifact.getFileName());
+      String dockerfile = dockerfileGenerator.generateDockerfile(artifact.getFileName(),
+                                                                 getRuntimeConfig());
       Path dockerFileDest = stagingDir.resolve("Dockerfile");
 
       try (BufferedWriter writer
@@ -112,6 +119,14 @@ public class StageDockerArtifactBuildStep extends BuildStep {
       // otherwise, search for an artifact in the workspace root
       return searchForArtifactInDir(directory);
     }
+  }
+
+  private RuntimeConfig getRuntimeConfig() {
+    if (this.runtimeConfig == null) {
+      this.runtimeConfig = new RuntimeConfig();
+    }
+
+    return this.runtimeConfig;
   }
 
   /*

--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/config/domain/RuntimeConfig.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/config/domain/RuntimeConfig.java
@@ -25,6 +25,7 @@ public class RuntimeConfig {
   private String buildScript;
   private String artifact;
   private String runtime;
+  private Boolean jettyQuickstart;
 
   public String getArtifact() {
     return artifact;
@@ -34,14 +35,12 @@ public class RuntimeConfig {
     this.artifact = artifact;
   }
 
-
   public String getRuntime() {
     return this.runtime;
   }
 
   public void setRuntime(String runtime) {
     this.runtime = runtime;
-
   }
 
   public String getBuildScript() {
@@ -51,5 +50,14 @@ public class RuntimeConfig {
   @JsonProperty("build_script")
   public void setBuildScript(String buildScript) {
     this.buildScript = buildScript;
+  }
+
+  public Boolean getJettyQuickstart() {
+    return jettyQuickstart;
+  }
+
+  @JsonProperty("jetty_quickstart")
+  public void setJettyQuickstart(Boolean jettyQuickstart) {
+    this.jettyQuickstart = jettyQuickstart;
   }
 }

--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/config/domain/RuntimeConfig.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/config/domain/RuntimeConfig.java
@@ -25,7 +25,7 @@ public class RuntimeConfig {
   private String buildScript;
   private String artifact;
   private String runtime;
-  private Boolean jettyQuickstart;
+  private boolean jettyQuickstart;
 
   public String getArtifact() {
     return artifact;
@@ -52,12 +52,12 @@ public class RuntimeConfig {
     this.buildScript = buildScript;
   }
 
-  public Boolean getJettyQuickstart() {
+  public boolean getJettyQuickstart() {
     return jettyQuickstart;
   }
 
   @JsonProperty("jetty_quickstart")
-  public void setJettyQuickstart(Boolean jettyQuickstart) {
+  public void setJettyQuickstart(boolean jettyQuickstart) {
     this.jettyQuickstart = jettyQuickstart;
   }
 }

--- a/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/BuildPipelineConfiguratorTest.java
+++ b/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/BuildPipelineConfiguratorTest.java
@@ -34,6 +34,7 @@ import com.google.cloud.runtimes.builder.buildsteps.ScriptExecutionBuildStep;
 import com.google.cloud.runtimes.builder.config.AppYamlParser;
 import com.google.cloud.runtimes.builder.config.YamlParser;
 import com.google.cloud.runtimes.builder.config.domain.AppYaml;
+import com.google.cloud.runtimes.builder.config.domain.RuntimeConfig;
 import com.google.cloud.runtimes.builder.exception.AppYamlNotFoundException;
 
 import org.junit.Before;
@@ -66,7 +67,7 @@ public class BuildPipelineConfiguratorTest {
 
     when(buildStepFactory.createMavenBuildStep()).thenReturn(mavenBuildStep);
     when(buildStepFactory.createGradleBuildStep()).thenReturn(gradleBuildStep);
-    when(buildStepFactory.createStageDockerArtifactBuildStep())
+    when(buildStepFactory.createStageDockerArtifactBuildStep(any(RuntimeConfig.class)))
         .thenReturn(stageDockerArtifactBuildStep);
     when(buildStepFactory.createScriptExecutionBuildStep(anyString()))
         .thenReturn(scriptExecutionBuildStep);

--- a/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/buildsteps/docker/DefaultDockerfileGeneratorTest.java
+++ b/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/buildsteps/docker/DefaultDockerfileGeneratorTest.java
@@ -16,8 +16,10 @@
 
 package com.google.cloud.runtimes.builder.buildsteps.docker;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.google.cloud.runtimes.builder.config.domain.RuntimeConfig;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -44,7 +46,7 @@ public class DefaultDockerfileGeneratorTest {
   @Test
   public void testGenerateOpenjdk() throws IOException {
     Path jar = Files.createTempFile( null, ".jar").toAbsolutePath();
-    String result = generator.generateDockerfile(jar);
+    String result = generator.generateDockerfile(jar, new RuntimeConfig());
     assertTrue(result.contains("FROM " + jarRuntime));
     assertTrue(result.contains("ADD " + jar.toString()));
   }
@@ -52,9 +54,31 @@ public class DefaultDockerfileGeneratorTest {
   @Test
   public void testGenerateJetty() throws IOException {
     Path war = Files.createTempFile( null, ".war").toAbsolutePath();
-    String result = generator.generateDockerfile(war);
+    String result = generator.generateDockerfile(war, new RuntimeConfig());
     assertTrue(result.contains("FROM " + serverRuntime));
     assertTrue(result.contains("ADD " + war.toString()));
+  }
+
+  @Test
+  public void testGenerateQuickstart() throws IOException {
+    Path war = Files.createTempFile(null, ".war").toAbsolutePath();
+    RuntimeConfig runtimeConfig = new RuntimeConfig();
+    runtimeConfig.setJettyQuickstart(true);
+    String dockerfile = generator.generateDockerfile(war, runtimeConfig);
+    assertTrue(dockerfile.contains("RUN /scripts/jetty/quickstart.sh"));
+  }
+
+  /**
+   * When Jetty quickstart is enabled but jetty runtime is not selected then the quickstart
+   * script must not be run.
+   */
+  @Test
+  public void testGenerateQuickstartWithoutJetty() throws IOException {
+    Path jar = Files.createTempFile( null, ".jar").toAbsolutePath();
+    RuntimeConfig runtimeConfig = new RuntimeConfig();
+    runtimeConfig.setJettyQuickstart(true);
+    String dockerfile = generator.generateDockerfile(jar, runtimeConfig);
+    assertFalse(dockerfile.contains("RUN /scripts/jetty/quickstart.sh"));
   }
 
 }

--- a/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/buildsteps/docker/DefaultDockerfileGeneratorTest.java
+++ b/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/buildsteps/docker/DefaultDockerfileGeneratorTest.java
@@ -60,12 +60,14 @@ public class DefaultDockerfileGeneratorTest {
   }
 
   @Test
-  public void testGenerateQuickstart() throws IOException {
+  public void testGenerateQuickstartJetty() throws IOException {
     Path war = Files.createTempFile(null, ".war").toAbsolutePath();
     RuntimeConfig runtimeConfig = new RuntimeConfig();
     runtimeConfig.setJettyQuickstart(true);
     String dockerfile = generator.generateDockerfile(war, runtimeConfig);
     assertTrue(dockerfile.contains("RUN /scripts/jetty/quickstart.sh"));
+    // The quickstart script must always be executed after adding the war
+    assertTrue(dockerfile.indexOf("ADD " + war.toString()) < dockerfile.indexOf("RUN /scripts/jetty/quickstart.sh"));
   }
 
   /**
@@ -73,7 +75,7 @@ public class DefaultDockerfileGeneratorTest {
    * script must not be run.
    */
   @Test
-  public void testGenerateQuickstartWithoutJetty() throws IOException {
+  public void testGenerateQuickstartOpenJdk() throws IOException {
     Path jar = Files.createTempFile( null, ".jar").toAbsolutePath();
     RuntimeConfig runtimeConfig = new RuntimeConfig();
     runtimeConfig.setJettyQuickstart(true);

--- a/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/buildsteps/docker/StageDockerArtifactBuildStepTest.java
+++ b/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/buildsteps/docker/StageDockerArtifactBuildStepTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 import com.google.cloud.runtimes.builder.TestUtils.TestWorkspaceBuilder;
 import com.google.cloud.runtimes.builder.buildsteps.base.BuildStepException;
 import com.google.cloud.runtimes.builder.buildsteps.base.BuildStepMetadataConstants;
+import com.google.cloud.runtimes.builder.config.domain.RuntimeConfig;
 import com.google.cloud.runtimes.builder.exception.ArtifactNotFoundException;
 import com.google.cloud.runtimes.builder.exception.TooManyArtifactsException;
 
@@ -50,7 +51,7 @@ public class StageDockerArtifactBuildStepTest {
   @Before
   public void setup() throws IOException {
     MockitoAnnotations.initMocks(this);
-    when(dockerfileGenerator.generateDockerfile(any(Path.class))).thenReturn("");
+    when(dockerfileGenerator.generateDockerfile(any(Path.class), any(RuntimeConfig.class))).thenReturn("");
     metadata = new HashMap<>();
   }
 
@@ -150,6 +151,7 @@ public class StageDockerArtifactBuildStepTest {
   private StageDockerArtifactBuildStep initBuildStep(String pathToArtifact) {
     StageDockerArtifactBuildStep buildStep = new StageDockerArtifactBuildStep(dockerfileGenerator);
     buildStep.setArtifactPathOverride(pathToArtifact);
+    buildStep.setRuntimeConfig(new RuntimeConfig());
     return buildStep;
   }
 

--- a/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/buildsteps/docker/StageDockerArtifactBuildStepTest.java
+++ b/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/buildsteps/docker/StageDockerArtifactBuildStepTest.java
@@ -149,9 +149,8 @@ public class StageDockerArtifactBuildStepTest {
   }
 
   private StageDockerArtifactBuildStep initBuildStep(String pathToArtifact) {
-    StageDockerArtifactBuildStep buildStep = new StageDockerArtifactBuildStep(dockerfileGenerator);
+    StageDockerArtifactBuildStep buildStep = new StageDockerArtifactBuildStep(dockerfileGenerator, new RuntimeConfig());
     buildStep.setArtifactPathOverride(pathToArtifact);
-    buildStep.setRuntimeConfig(new RuntimeConfig());
     return buildStep;
   }
 

--- a/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/config/AppYamlParserTest.java
+++ b/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/config/AppYamlParserTest.java
@@ -17,13 +17,11 @@
 package com.google.cloud.runtimes.builder.config;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.runtimes.builder.config.domain.AppYaml;
 
-import com.sun.xml.internal.ws.policy.privateutil.PolicyUtils.IO;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -82,7 +80,7 @@ public class AppYamlParserTest {
   }
 
   @Test
-  public void testParse_jettyQuickstart() throws IOException {
+  public void testParseJettyQuickstart() throws IOException {
     AppYaml result = parseFileWithContents(APP_YAML_PREAMBLE
         + "runtime_config:\n"
         + "  jetty_quickstart: true");
@@ -90,7 +88,7 @@ public class AppYamlParserTest {
   }
 
   @Test(expected = com.fasterxml.jackson.databind.exc.InvalidFormatException.class)
-  public void testParse_invalidJettyQuickstart() throws IOException {
+  public void testParseInvalidJettyQuickstart() throws IOException {
     parseFileWithContents(APP_YAML_PREAMBLE
         + "runtime_config:\n"
         + "  jetty_quickstart: invalid_quickstart_option");

--- a/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/config/AppYamlParserTest.java
+++ b/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/config/AppYamlParserTest.java
@@ -17,10 +17,13 @@
 package com.google.cloud.runtimes.builder.config;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.runtimes.builder.config.domain.AppYaml;
 
+import com.sun.xml.internal.ws.policy.privateutil.PolicyUtils.IO;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -76,6 +79,21 @@ public class AppYamlParserTest {
         + "runtime_config:\n"
         + "  artifact: " + artifact);
     assertEquals(artifact, result.getRuntimeConfig().getArtifact());
+  }
+
+  @Test
+  public void testParse_jettyQuickstart() throws IOException {
+    AppYaml result = parseFileWithContents(APP_YAML_PREAMBLE
+        + "runtime_config:\n"
+        + "  jetty_quickstart: true");
+    assertTrue(result.getRuntimeConfig().getJettyQuickstart());
+  }
+
+  @Test(expected = com.fasterxml.jackson.databind.exc.InvalidFormatException.class)
+  public void testParse_invalidJettyQuickstart() throws IOException {
+    parseFileWithContents(APP_YAML_PREAMBLE
+        + "runtime_config:\n"
+        + "  jetty_quickstart: invalid_quickstart_option");
   }
 
 }


### PR DESCRIPTION
Add the possibility to enable quickstart for the Jetty runtime by specifying it in app.yaml.

The following syntax can be used:
``` app.yaml
runtime: java
env: flex

runtime_config:
    jetty_quickstart: true/false

```

This PR fix #42 