### PR TITLE
Docker image enhancements

### DIFF
--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/buildsteps/MavenBuildStep.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/buildsteps/MavenBuildStep.java
@@ -53,7 +53,7 @@ public class MavenBuildStep extends AbstractSubprocessBuildStep {
 
   @VisibleForTesting
   String getMavenHome() {
-    return System.getenv("M2_HOME");
+    return System.getenv("MAVEN_HOME");
   }
 
   private String getMavenExecutable(Path directory) {
@@ -64,11 +64,11 @@ public class MavenBuildStep extends AbstractSubprocessBuildStep {
       return wrapperPath.toString();
     }
 
-    String m2Home = getMavenHome();
-    if (Strings.isNullOrEmpty(m2Home)) {
-      throw new IllegalStateException("$M2_HOME must be set.");
+    String mavenHome = getMavenHome();
+    if (Strings.isNullOrEmpty(mavenHome)) {
+      throw new IllegalStateException("$MAVEN_HOME must be set.");
     }
-    Path systemMvn = Paths.get(m2Home).resolve("bin").resolve("mvn");
+    Path systemMvn = Paths.get(mavenHome).resolve("bin").resolve("mvn");
     if (Files.isExecutable(systemMvn)) {
       return systemMvn.toString();
     }

--- a/java-runtime-builder-docker/src/main/resources/docker/Dockerfile
+++ b/java-runtime-builder-docker/src/main/resources/docker/Dockerfile
@@ -1,29 +1,21 @@
-FROM gcr.io/google-appengine/openjdk
-
-# install utilities
-RUN apt-get -q update \
-  && apt-get -q -y --no-install-recommends install curl \
-  && apt-get clean \
-  && rm /var/lib/apt/lists/*_*
-
-# install maven
-ARG MAVEN_VERSION=3.3.9
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL https://apache.osuosl.org/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz \
-    | tar -xzC /usr/share/maven --strip-components=1 \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
-ENV M2_HOME /usr/share/maven
-
-# install gradle
+# Use wget container to download gradle
+FROM gcr.io/cloud-builders/wget as wget
 ARG GRADLE_VERSION=3.4
 RUN mkdir -p /usr/share/gradle \
-  && curl -fsSLO https://services.gradle.org/distributions/gradle-$GRADLE_VERSION-bin.zip \
-  && unzip -qq gradle-$GRADLE_VERSION-bin.zip \
-  && rm gradle-$GRADLE_VERSION-bin.zip \
+  && wget -nv -O gradle-$GRADLE_VERSION-bin.zip https://services.gradle.org/distributions/gradle-$GRADLE_VERSION-bin.zip
+
+FROM gcr.io/cloud-builders/java/mvn:3.5.0-jdk-8
+ARG GRADLE_VERSION=3.4
+# copy gradle installation from wget container
+COPY --from=wget gradle-$GRADLE_VERSION-bin.zip .
+# unpack and install gradle
+RUN unzip -qq gradle-$GRADLE_VERSION-bin.zip \
   && mkdir -p /usr/share/ \
   && mv gradle-$GRADLE_VERSION /usr/share/ \
   && ln -s /usr/share/gradle-$GRADLE_VERSION/bin/gradle /usr/bin/gradle
 ENV GRADLE_HOME /usr/share/gradle-$GRADLE_VERSION
 
+# add the runtime builder application
 ADD ${runtime.builder.artifact} /${runtime.builder.artifact}
+
 ENTRYPOINT ["java", "-jar", "/${runtime.builder.artifact}"]

--- a/java-runtime-builder-docker/src/main/resources/docker/Dockerfile
+++ b/java-runtime-builder-docker/src/main/resources/docker/Dockerfile
@@ -1,18 +1,14 @@
-# Use wget container to download gradle
-FROM gcr.io/cloud-builders/wget as wget
-ARG GRADLE_VERSION=3.4
-RUN mkdir -p /usr/share/gradle \
-  && wget -nv -O gradle-$GRADLE_VERSION-bin.zip https://services.gradle.org/distributions/gradle-$GRADLE_VERSION-bin.zip
-
 FROM gcr.io/cloud-builders/java/mvn:3.5.0-jdk-8
+
 ARG GRADLE_VERSION=3.4
-# copy gradle installation from wget container
-COPY --from=wget gradle-$GRADLE_VERSION-bin.zip .
-# unpack and install gradle
+
+# download and install gradle
+ADD https://services.gradle.org/distributions/gradle-$GRADLE_VERSION-bin.zip gradle-$GRADLE_VERSION-bin.zip
 RUN unzip -qq gradle-$GRADLE_VERSION-bin.zip \
   && mkdir -p /usr/share/ \
   && mv gradle-$GRADLE_VERSION /usr/share/ \
   && ln -s /usr/share/gradle-$GRADLE_VERSION/bin/gradle /usr/bin/gradle
+
 ENV GRADLE_HOME /usr/share/gradle-$GRADLE_VERSION
 
 # add the runtime builder application

--- a/java-runtime-builder-docker/src/main/resources/docker/Dockerfile
+++ b/java-runtime-builder-docker/src/main/resources/docker/Dockerfile
@@ -5,6 +5,7 @@ ARG GRADLE_VERSION=3.4
 # download and install gradle
 ADD https://services.gradle.org/distributions/gradle-$GRADLE_VERSION-bin.zip gradle-$GRADLE_VERSION-bin.zip
 RUN unzip -qq gradle-$GRADLE_VERSION-bin.zip \
+  && rm gradle-$GRADLE_VERSION-bin.zip \
   && mkdir -p /usr/share/ \
   && mv gradle-$GRADLE_VERSION /usr/share/ \
   && ln -s /usr/share/gradle-$GRADLE_VERSION/bin/gradle /usr/bin/gradle

--- a/scripts/pipeline-cloudbuild.yaml
+++ b/scripts/pipeline-cloudbuild.yaml
@@ -3,8 +3,8 @@
 
 steps:
 # Build the maven project, omitting the docker build step
-- name: 'maven:3.3.9-jdk-8'
-  args: ['mvn', '-P-local-docker-build', 'clean', 'install']
+- name: 'gcr.io/cloud-builders/java/mvn:3.5.0-jdk-8'
+  args: ['-P-local-docker-build', 'clean', 'install']
   id: 'MAVEN'
 
 # Execute the docker build

--- a/test/structure/structure.yaml
+++ b/test/structure/structure.yaml
@@ -6,11 +6,11 @@ schemaVersion: 1.0.0
 commandTests:
 - name: 'maven is installed'
   command: ['mvn', '--version']
-  expectedOutput: 'Apache Maven 3.3.9'
+  expectedOutput: ['Apache Maven 3.5.0']
   exitCode: '0'
 - name: 'gradle is installed'
   command: ['gradle', '--version']
-  expectedOutput: 'Gradle 1.4'
+  expectedOutput: ['Gradle 3.4']
   exitCode: '0'
 - name: 'correct java version is installed'
   command: ['java', '-version']
@@ -20,4 +20,10 @@ commandTests:
   command: ['javac', '-version']
   expectedError: ['javac 1\.8\.0_121']
   exitCode: '0'
+- name: 'MAVEN_HOME is set'
+  command: ['env']
+  expectedOutput: ['MAVEN_HOME=/usr/share/maven']
+- name: 'GRADLE_HOME is set'
+  command: ['env']
+  expectedOutput: ['GRADLE_HOME=/usr/share/gradle-3.4']
 


### PR DESCRIPTION
This PR modifies the builder's docker images to use gcr.io/cloud-builders/java/mvn as the base image, which has a lighter footprint than the gcr.io/google-appengine/openjdk runtime, and contains pre-cached maven dependencies.

These changes result in a reduction in the size of the runtime-builder image from 448MB to 341MB, despite also including pre-cached maven deps.