### PR TITLE
Test for presence of Dockerfile

### DIFF
--- a/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/BuildPipelineConfiguratorTest.java
+++ b/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/BuildPipelineConfiguratorTest.java
@@ -156,4 +156,14 @@ public class BuildPipelineConfiguratorTest {
         .createScriptExecutionBuildStep(eq(buildScript));
   }
 
+  @Test(expected = IllegalStateException.class)
+  public void test_providedDockerfile() throws AppYamlNotFoundException, IOException {
+    Path workspace = new TestWorkspaceBuilder()
+        .file("app.yaml").withContents("env: flex\nruntime: java").build()
+        .file("Dockerfile").build()
+        .build();
+
+    buildPipelineConfigurator.configurePipeline(workspace);
+  }
+
 }


### PR DESCRIPTION
fixes #45  

If a Dockerfile is found at the root, the execution exits immediately with an error. I chose to only look at the path `$workspace_dir/Dockerfile` for this file. Any thoughts about that choice? I'm open to changing it.