### PR TITLE
Support yaml file location via GAE_APPLICATION_YAML_PATH variable

### DIFF
--- a/java-runtime-builder-app/pom.xml
+++ b/java-runtime-builder-app/pom.xml
@@ -84,11 +84,6 @@
       <artifactId>commons-io</artifactId>
       <version>2.5</version>
     </dependency>
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>3.0.2</version>
-    </dependency>
   </dependencies>
 
   <build>

--- a/java-runtime-builder-app/pom.xml
+++ b/java-runtime-builder-app/pom.xml
@@ -84,6 +84,11 @@
       <artifactId>commons-io</artifactId>
       <version>2.5</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>3.0.2</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/config/AppYamlFinder.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/config/AppYamlFinder.java
@@ -19,6 +19,7 @@ package com.google.cloud.runtimes.builder.config;
 import com.google.cloud.runtimes.builder.exception.AppYamlNotFoundException;
 import com.google.cloud.runtimes.builder.injection.ConfigYamlPath;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.inject.Inject;
 
@@ -49,20 +50,21 @@ public class AppYamlFinder {
   }
 
   /**
-   * Search for app.yaml in a few expected paths within the given path.
+   * Search for app.yaml in a few expected paths within a directory
    *
-   * @param searchPath a directory to search in
+   * @param searchDir a directory to search in
    * @return the path to the config file
    * @throws AppYamlNotFoundException if no valid config file is found
    */
-  public Path findAppYamlFile(Path searchPath) throws AppYamlNotFoundException {
-    // Check in expected locations
+  public Path findAppYamlFile(Path searchDir) throws AppYamlNotFoundException {
+    Preconditions.checkArgument(Files.isDirectory(searchDir));
+
     return appYamlSearchPaths.stream()
-        .map(pathName -> searchPath.resolve(pathName))
+        .map(pathName -> searchDir.resolve(pathName))
         .filter(path -> Files.exists(path) && Files.isRegularFile(path))
         .findFirst()
         .orElseThrow(() -> new AppYamlNotFoundException("An app.yaml configuration file is "
-            + "required, but was not found in the included sources."));
+            + "required, but was not found in the included files."));
   }
 
 }

--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/config/AppYamlFinder.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/config/AppYamlFinder.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.runtimes.builder.config;
+
+import com.google.cloud.runtimes.builder.exception.AppYamlNotFoundException;
+import com.google.cloud.runtimes.builder.injection.ConfigYamlPath;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
+import com.google.inject.Inject;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import javax.annotation.Nullable;
+
+public class AppYamlFinder {
+
+  private final List<String> appYamlSearchPaths = new LinkedList<>(
+      Arrays.asList("app.yaml", "src/main/appengine/app.yaml"));
+
+  /**
+   * Constructs a new {@link AppYamlFinder}.
+   *
+   * @param configYamlPath the expected path for a config file to be found
+   */
+  @Inject
+  @VisibleForTesting
+  public AppYamlFinder(@Nullable @ConfigYamlPath String configYamlPath) {
+    // this config location takes priority, so insert it at front of the search list
+    if (!Strings.isNullOrEmpty(configYamlPath)) {
+      appYamlSearchPaths.add(0, configYamlPath);
+    }
+  }
+
+  /**
+   * Search for app.yaml in a few expected paths within the given path.
+   *
+   * @param searchPath a directory to search in
+   * @return the path to the config file
+   * @throws AppYamlNotFoundException if no valid config file is found
+   */
+  public Path findAppYamlFile(Path searchPath) throws AppYamlNotFoundException {
+    // Check in expected locations
+    return appYamlSearchPaths.stream()
+        .map(pathName -> searchPath.resolve(pathName))
+        .filter(path -> Files.exists(path) && Files.isRegularFile(path))
+        .findFirst()
+        .orElseThrow(() -> new AppYamlNotFoundException("An app.yaml configuration file is "
+            + "required, but was not found in the included sources."));
+  }
+
+}

--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/config/AppYamlFinder.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/config/AppYamlFinder.java
@@ -27,7 +27,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
-import javax.annotation.Nullable;
 
 public class AppYamlFinder {
 
@@ -38,12 +37,12 @@ public class AppYamlFinder {
   /**
    * Constructs a new {@link AppYamlFinder}.
    *
-   * @param configYamlPath the expected path for a config file to be found
+   * @param providedConfigPath the expected path for a config file to be found
    */
   @Inject
   @VisibleForTesting
-  public AppYamlFinder(@Nullable @ConfigYamlPath String configYamlPath) {
-    this.providedConfigPath = Optional.ofNullable(configYamlPath);
+  public AppYamlFinder(@ConfigYamlPath Optional<String> providedConfigPath) {
+    this.providedConfigPath = providedConfigPath;
   }
 
   /**

--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/injection/ConfigYamlPath.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/injection/ConfigYamlPath.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.runtimes.builder.injection;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@BindingAnnotation
+@Target({ FIELD, PARAMETER, METHOD }) @Retention(RUNTIME)
+public @interface ConfigYamlPath {}

--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/injection/RootModule.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/injection/RootModule.java
@@ -19,6 +19,7 @@ package com.google.cloud.runtimes.builder.injection;
 import com.google.cloud.runtimes.builder.buildsteps.base.BuildStepFactory;
 import com.google.cloud.runtimes.builder.buildsteps.docker.DefaultDockerfileGenerator;
 import com.google.cloud.runtimes.builder.buildsteps.docker.DockerfileGenerator;
+import com.google.cloud.runtimes.builder.config.AppYamlFinder;
 import com.google.cloud.runtimes.builder.config.AppYamlParser;
 import com.google.cloud.runtimes.builder.config.YamlParser;
 import com.google.cloud.runtimes.builder.config.domain.AppYaml;
@@ -41,6 +42,7 @@ public class RootModule extends AbstractModule {
 
   private final String[] jdkMappings;
   private final String[] serverMappings;
+  private static final String CONFIG_YAML_ENV_VAR = "GAE_APPLICATION_YAML_PATH";
 
   /**
    * Constructs a new {@link RootModule} for Guice.
@@ -58,10 +60,15 @@ public class RootModule extends AbstractModule {
 
   @Override
   protected void configure() {
+    bind(String.class)
+        .annotatedWith(ConfigYamlPath.class)
+        .toInstance(System.getenv(CONFIG_YAML_ENV_VAR));
+
     bind(new TypeLiteral<YamlParser<AppYaml>>(){})
         .to(AppYamlParser.class);
     bind(DockerfileGenerator.class)
         .to(DefaultDockerfileGenerator.class);
+    bind(AppYamlFinder.class);
 
     install(new FactoryModuleBuilder()
         .build(BuildStepFactory.class));

--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/injection/RootModule.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/injection/RootModule.java
@@ -29,11 +29,11 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.TypeLiteral;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
-import com.google.inject.util.Providers;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -61,9 +61,9 @@ public class RootModule extends AbstractModule {
 
   @Override
   protected void configure() {
-    bind(String.class)
+    bind(new TypeLiteral<Optional<String>>(){})
         .annotatedWith(ConfigYamlPath.class)
-        .toProvider(Providers.of(System.getenv(CONFIG_YAML_ENV_VAR)));
+        .toInstance(Optional.ofNullable(System.getenv(CONFIG_YAML_ENV_VAR)));
 
     bind(new TypeLiteral<YamlParser<AppYaml>>(){})
         .to(AppYamlParser.class);

--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/injection/RootModule.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/injection/RootModule.java
@@ -29,6 +29,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.TypeLiteral;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
+import com.google.inject.util.Providers;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -62,7 +63,7 @@ public class RootModule extends AbstractModule {
   protected void configure() {
     bind(String.class)
         .annotatedWith(ConfigYamlPath.class)
-        .toInstance(System.getenv(CONFIG_YAML_ENV_VAR));
+        .toProvider(Providers.of(System.getenv(CONFIG_YAML_ENV_VAR)));
 
     bind(new TypeLiteral<YamlParser<AppYaml>>(){})
         .to(AppYamlParser.class);

--- a/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/BuildPipelineConfiguratorTest.java
+++ b/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/BuildPipelineConfiguratorTest.java
@@ -46,6 +46,7 @@ import org.mockito.MockitoAnnotations;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Unit tests for {@link BuildPipelineConfigurator}
@@ -60,7 +61,7 @@ public class BuildPipelineConfiguratorTest {
 
   // use the actual yaml parser and yaml finders instead of mocks
   private YamlParser<AppYaml> appYamlYamlParser = new AppYamlParser();
-  private AppYamlFinder appYamlFinder = new AppYamlFinder(null);
+  private AppYamlFinder appYamlFinder = new AppYamlFinder(Optional.empty());
   private BuildPipelineConfigurator buildPipelineConfigurator;
 
   @Before

--- a/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/BuildPipelineConfiguratorTest.java
+++ b/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/BuildPipelineConfiguratorTest.java
@@ -25,12 +25,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.runtimes.builder.TestUtils.TestWorkspaceBuilder;
-import com.google.cloud.runtimes.builder.buildsteps.base.BuildStep;
-import com.google.cloud.runtimes.builder.buildsteps.base.BuildStepFactory;
-import com.google.cloud.runtimes.builder.buildsteps.docker.StageDockerArtifactBuildStep;
 import com.google.cloud.runtimes.builder.buildsteps.GradleBuildStep;
 import com.google.cloud.runtimes.builder.buildsteps.MavenBuildStep;
 import com.google.cloud.runtimes.builder.buildsteps.ScriptExecutionBuildStep;
+import com.google.cloud.runtimes.builder.buildsteps.base.BuildStep;
+import com.google.cloud.runtimes.builder.buildsteps.base.BuildStepFactory;
+import com.google.cloud.runtimes.builder.buildsteps.docker.StageDockerArtifactBuildStep;
 import com.google.cloud.runtimes.builder.config.AppYamlFinder;
 import com.google.cloud.runtimes.builder.config.AppYamlParser;
 import com.google.cloud.runtimes.builder.config.YamlParser;
@@ -38,7 +38,6 @@ import com.google.cloud.runtimes.builder.config.domain.AppYaml;
 import com.google.cloud.runtimes.builder.config.domain.RuntimeConfig;
 import com.google.cloud.runtimes.builder.exception.AppYamlNotFoundException;
 
-import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;

--- a/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/BuildPipelineConfiguratorTest.java
+++ b/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/BuildPipelineConfiguratorTest.java
@@ -31,12 +31,14 @@ import com.google.cloud.runtimes.builder.buildsteps.docker.StageDockerArtifactBu
 import com.google.cloud.runtimes.builder.buildsteps.GradleBuildStep;
 import com.google.cloud.runtimes.builder.buildsteps.MavenBuildStep;
 import com.google.cloud.runtimes.builder.buildsteps.ScriptExecutionBuildStep;
+import com.google.cloud.runtimes.builder.config.AppYamlFinder;
 import com.google.cloud.runtimes.builder.config.AppYamlParser;
 import com.google.cloud.runtimes.builder.config.YamlParser;
 import com.google.cloud.runtimes.builder.config.domain.AppYaml;
 import com.google.cloud.runtimes.builder.config.domain.RuntimeConfig;
 import com.google.cloud.runtimes.builder.exception.AppYamlNotFoundException;
 
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -57,8 +59,9 @@ public class BuildPipelineConfiguratorTest {
   @Mock private StageDockerArtifactBuildStep stageDockerArtifactBuildStep;
   @Mock private ScriptExecutionBuildStep scriptExecutionBuildStep;
 
-  // use the actual yaml parser instead of a mock.
+  // use the actual yaml parser and yaml finders instead of mocks
   private YamlParser<AppYaml> appYamlYamlParser = new AppYamlParser();
+  private AppYamlFinder appYamlFinder = new AppYamlFinder(null);
   private BuildPipelineConfigurator buildPipelineConfigurator;
 
   @Before
@@ -72,7 +75,8 @@ public class BuildPipelineConfiguratorTest {
     when(buildStepFactory.createScriptExecutionBuildStep(anyString()))
         .thenReturn(scriptExecutionBuildStep);
 
-    buildPipelineConfigurator = new BuildPipelineConfigurator(appYamlYamlParser, buildStepFactory);
+    buildPipelineConfigurator
+        = new BuildPipelineConfigurator(appYamlYamlParser, appYamlFinder, buildStepFactory);
   }
 
   @Test

--- a/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/config/AppYamlFinderTest.java
+++ b/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/config/AppYamlFinderTest.java
@@ -1,7 +1,7 @@
 package com.google.cloud.runtimes.builder.config;
 
+import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.runtimes.builder.TestUtils.TestWorkspaceBuilder;
 import com.google.cloud.runtimes.builder.exception.AppYamlNotFoundException;
@@ -65,7 +65,7 @@ public class AppYamlFinderTest {
   public void testDirectoryAsAppYaml() throws IOException, AppYamlNotFoundException {
     Path workspace = new TestWorkspaceBuilder().build();
     Optional<Path> result = new AppYamlFinder(Optional.empty()).findAppYamlFile(workspace);
-    assertTrue(!result.isPresent());
+    assertFalse(result.isPresent());
   }
 
   @Test
@@ -74,7 +74,7 @@ public class AppYamlFinderTest {
         .file("other.yaml").build()
         .build();
     Optional<Path> result = new AppYamlFinder(Optional.empty()).findAppYamlFile(workspace);
-    assertTrue(!result.isPresent());
+    assertFalse(result.isPresent());
 
   }
 

--- a/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/config/AppYamlFinderTest.java
+++ b/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/config/AppYamlFinderTest.java
@@ -1,0 +1,79 @@
+package com.google.cloud.runtimes.builder.config;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.cloud.runtimes.builder.TestUtils.TestWorkspaceBuilder;
+import com.google.cloud.runtimes.builder.exception.AppYamlNotFoundException;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Unit tests for {@link AppYamlFinder}
+ */
+public class AppYamlFinderTest {
+
+  @Test
+  public void testAppYamlAtRootNoEnvVar() throws IOException, AppYamlNotFoundException {
+    String yamlPath = "app.yaml";
+    Path workspace = new TestWorkspaceBuilder()
+        .file(yamlPath).build()
+        .build();
+
+    Path result = new AppYamlFinder(null).findAppYamlFile(workspace);
+    assertEquals(workspace.resolve(yamlPath), result);
+  }
+
+  @Test
+  public void testAppYamlAtSrcMainNoEnvVar() throws IOException, AppYamlNotFoundException {
+    String yamlPath = "src/main/appengine/app.yaml";
+    Path workspace = new TestWorkspaceBuilder()
+        .file(yamlPath).build()
+        .build();
+
+    Path result = new AppYamlFinder(null).findAppYamlFile(workspace);
+    assertEquals(workspace.resolve(yamlPath), result);
+  }
+
+  @Test
+  public void testAppYamlWithEnvVar() throws IOException, AppYamlNotFoundException {
+    String pathFromEnvVar = "somedir/arbitraryfile";
+    Path workspace = new TestWorkspaceBuilder()
+        .file("app.yaml").build()
+        .file(pathFromEnvVar).build()
+        .build();
+
+    Path result = new AppYamlFinder(pathFromEnvVar).findAppYamlFile(workspace);
+    assertEquals(workspace.resolve(pathFromEnvVar), result);
+  }
+
+  @Test
+  public void testAppYamlWithInvalidEnvVar() throws IOException, AppYamlNotFoundException {
+    String appYamlDefaultPath = "app.yaml";
+    Path workspace = new TestWorkspaceBuilder()
+        .file(appYamlDefaultPath).build()
+        .build();
+
+    Path result = new AppYamlFinder("path/does/not/exist").findAppYamlFile(workspace);
+    assertEquals(workspace.resolve(appYamlDefaultPath), result);
+  }
+
+  @Test(expected = AppYamlNotFoundException.class)
+  public void testDirectoryAsAppYaml() throws IOException, AppYamlNotFoundException {
+    Path workspace = new TestWorkspaceBuilder().build();
+    new AppYamlFinder(null).findAppYamlFile(workspace);
+  }
+
+  @Test(expected = AppYamlNotFoundException.class)
+  public void testAppYamlNotPresent() throws AppYamlNotFoundException, IOException {
+    Path workspace = new TestWorkspaceBuilder()
+        .file("other.yaml").build()
+        .build();
+    new AppYamlFinder(null).findAppYamlFile(workspace);
+
+  }
+
+}

--- a/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/config/AppYamlFinderTest.java
+++ b/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/config/AppYamlFinderTest.java
@@ -1,6 +1,7 @@
 package com.google.cloud.runtimes.builder.config;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.runtimes.builder.TestUtils.TestWorkspaceBuilder;
 import com.google.cloud.runtimes.builder.exception.AppYamlNotFoundException;
@@ -8,8 +9,8 @@ import com.google.cloud.runtimes.builder.exception.AppYamlNotFoundException;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
 
 /**
  * Unit tests for {@link AppYamlFinder}
@@ -23,8 +24,8 @@ public class AppYamlFinderTest {
         .file(yamlPath).build()
         .build();
 
-    Path result = new AppYamlFinder(null).findAppYamlFile(workspace);
-    assertEquals(workspace.resolve(yamlPath), result);
+    Optional<Path> result = new AppYamlFinder(null).findAppYamlFile(workspace);
+    assertEquals(workspace.resolve(yamlPath), result.get());
   }
 
   @Test
@@ -34,8 +35,8 @@ public class AppYamlFinderTest {
         .file(yamlPath).build()
         .build();
 
-    Path result = new AppYamlFinder(null).findAppYamlFile(workspace);
-    assertEquals(workspace.resolve(yamlPath), result);
+    Optional<Path> result = new AppYamlFinder(null).findAppYamlFile(workspace);
+    assertEquals(workspace.resolve(yamlPath), result.get());
   }
 
   @Test
@@ -46,33 +47,34 @@ public class AppYamlFinderTest {
         .file(pathFromEnvVar).build()
         .build();
 
-    Path result = new AppYamlFinder(pathFromEnvVar).findAppYamlFile(workspace);
-    assertEquals(workspace.resolve(pathFromEnvVar), result);
+    Optional<Path> result = new AppYamlFinder(pathFromEnvVar).findAppYamlFile(workspace);
+    assertEquals(workspace.resolve(pathFromEnvVar), result.get());
   }
 
-  @Test
+  @Test(expected = AppYamlNotFoundException.class)
   public void testAppYamlWithInvalidEnvVar() throws IOException, AppYamlNotFoundException {
     String appYamlDefaultPath = "app.yaml";
     Path workspace = new TestWorkspaceBuilder()
         .file(appYamlDefaultPath).build()
         .build();
 
-    Path result = new AppYamlFinder("path/does/not/exist").findAppYamlFile(workspace);
-    assertEquals(workspace.resolve(appYamlDefaultPath), result);
+    new AppYamlFinder("path/does/not/exist").findAppYamlFile(workspace);
   }
 
-  @Test(expected = AppYamlNotFoundException.class)
+  @Test
   public void testDirectoryAsAppYaml() throws IOException, AppYamlNotFoundException {
     Path workspace = new TestWorkspaceBuilder().build();
-    new AppYamlFinder(null).findAppYamlFile(workspace);
+    Optional<Path> result = new AppYamlFinder(null).findAppYamlFile(workspace);
+    assertTrue(!result.isPresent());
   }
 
-  @Test(expected = AppYamlNotFoundException.class)
+  @Test
   public void testAppYamlNotPresent() throws AppYamlNotFoundException, IOException {
     Path workspace = new TestWorkspaceBuilder()
         .file("other.yaml").build()
         .build();
-    new AppYamlFinder(null).findAppYamlFile(workspace);
+    Optional<Path> result = new AppYamlFinder(null).findAppYamlFile(workspace);
+    assertTrue(!result.isPresent());
 
   }
 

--- a/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/config/AppYamlFinderTest.java
+++ b/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/config/AppYamlFinderTest.java
@@ -24,7 +24,7 @@ public class AppYamlFinderTest {
         .file(yamlPath).build()
         .build();
 
-    Optional<Path> result = new AppYamlFinder(null).findAppYamlFile(workspace);
+    Optional<Path> result = new AppYamlFinder(Optional.empty()).findAppYamlFile(workspace);
     assertEquals(workspace.resolve(yamlPath), result.get());
   }
 
@@ -35,7 +35,7 @@ public class AppYamlFinderTest {
         .file(yamlPath).build()
         .build();
 
-    Optional<Path> result = new AppYamlFinder(null).findAppYamlFile(workspace);
+    Optional<Path> result = new AppYamlFinder(Optional.empty()).findAppYamlFile(workspace);
     assertEquals(workspace.resolve(yamlPath), result.get());
   }
 
@@ -47,7 +47,7 @@ public class AppYamlFinderTest {
         .file(pathFromEnvVar).build()
         .build();
 
-    Optional<Path> result = new AppYamlFinder(pathFromEnvVar).findAppYamlFile(workspace);
+    Optional<Path> result = new AppYamlFinder(Optional.of(pathFromEnvVar)).findAppYamlFile(workspace);
     assertEquals(workspace.resolve(pathFromEnvVar), result.get());
   }
 
@@ -58,13 +58,13 @@ public class AppYamlFinderTest {
         .file(appYamlDefaultPath).build()
         .build();
 
-    new AppYamlFinder("path/does/not/exist").findAppYamlFile(workspace);
+    new AppYamlFinder(Optional.of("path/does/not/exist")).findAppYamlFile(workspace);
   }
 
   @Test
   public void testDirectoryAsAppYaml() throws IOException, AppYamlNotFoundException {
     Path workspace = new TestWorkspaceBuilder().build();
-    Optional<Path> result = new AppYamlFinder(null).findAppYamlFile(workspace);
+    Optional<Path> result = new AppYamlFinder(Optional.empty()).findAppYamlFile(workspace);
     assertTrue(!result.isPresent());
   }
 
@@ -73,7 +73,7 @@ public class AppYamlFinderTest {
     Path workspace = new TestWorkspaceBuilder()
         .file("other.yaml").build()
         .build();
-    Optional<Path> result = new AppYamlFinder(null).findAppYamlFile(workspace);
+    Optional<Path> result = new AppYamlFinder(Optional.empty()).findAppYamlFile(workspace);
     assertTrue(!result.isPresent());
 
   }


### PR DESCRIPTION
fixes #58

This PR allows the app.yaml location to be passed into the builder via an environment variable, but does not modify `java.yaml` to actually pass it in. That change will need to wait until gcloud supports that substitution.