### PR TITLE
Replace java.util.logging with logback

### DIFF
--- a/java-runtime-builder-app/pom.xml
+++ b/java-runtime-builder-app/pom.xml
@@ -16,20 +16,13 @@
   <properties>
     <jackson.version>2.8.4</jackson.version>
     <guice.version>4.1.0</guice.version>
-    <slf4j.version>1.7.22</slf4j.version>
   </properties>
 
   <dependencies>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-jdk14</artifactId>
-      <scope>runtime</scope>
-      <version>${slf4j.version}</version>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.0.13</version>
     </dependency>
     <dependency>
       <groupId>com.google.inject</groupId>

--- a/java-runtime-builder-app/src/main/resources/logback.xml
+++ b/java-runtime-builder-app/src/main/resources/logback.xml
@@ -1,0 +1,12 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%-5level - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="debug">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/java-runtime-builder-app/src/main/resources/logging.properties
+++ b/java-runtime-builder-app/src/main/resources/logging.properties
@@ -1,4 +1,0 @@
-handlers = java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.level = ALL
-java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
-java.util.logging.SimpleFormatter.format = [%4$s] %5$s %6$s%n

--- a/java-runtime-builder-docker/src/main/resources/docker/Dockerfile
+++ b/java-runtime-builder-docker/src/main/resources/docker/Dockerfile
@@ -15,4 +15,4 @@ ENV GRADLE_HOME /usr/share/gradle-$GRADLE_VERSION
 # add the runtime builder application
 ADD ${runtime.builder.artifact} /${runtime.builder.artifact}
 
-ENTRYPOINT ["java", "-Djava.util.logging.config.file=logging.properties", "-jar", "/${runtime.builder.artifact}"]
+ENTRYPOINT ["java", "-jar", "/${runtime.builder.artifact}"]


### PR DESCRIPTION
Prior to this PR, java util logging was misconfigured and was failing silently.

Java util logging requires a `logging.properties` file to be present in order to configure logging. This file can't be loaded from the classpath (at least not without some additional code to locate and load the config file). By switching to logback, we can package logging configuration in the `java-runtime-builder-app` executable jar. This also has the benefit of simplifying our Dockerfile.