### PR TITLE
Implement unfinished test

### DIFF
--- a/test/integration/tests/gradle-wrapper-jar/structure.yaml
+++ b/test/integration/tests/gradle-wrapper-jar/structure.yaml
@@ -8,6 +8,6 @@ commandTests:
 
 fileExistenceTests:
 - name: 'test application exists'
-  path: '/var/lib/jetty/webapps/root.war' # TODO
+  path: 'app.jar'
   isDirectory: false
   shouldExist: true


### PR DESCRIPTION
This PR fixes an unfinished integration test that slipped in with https://github.com/GoogleCloudPlatform/runtime-builder-java/pull/63, breaking continuous integration.