### PR TITLE
Update Builder Structure Tests

### DIFF
--- a/test/structure/structure.yaml
+++ b/test/structure/structure.yaml
@@ -20,9 +20,9 @@ commandTests:
   command: ['javac', '-version']
   expectedError: ['javac 1\.8\.0_131']
   exitCode: '0'
-- name: 'MAVEN_HOME is set'
+- name: 'M2_HOME is set'
   command: ['env']
-  expectedOutput: ['MAVEN_HOME=/usr/share/maven']
+  expectedOutput: ['M2_HOME=/usr/share/maven']
 - name: 'GRADLE_HOME is set'
   command: ['env']
   expectedOutput: ['GRADLE_HOME=/usr/share/gradle-3.4']


### PR DESCRIPTION
The builder's base image (gcr.io/cloud-builders/java/mvn) has been changed to use the more standard `M2_HOME` env variable. This PR updates our structure tests to reflect that.