### PR TITLE
Add app.yaml to generated .dockerignore file

### DIFF
--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/BuildPipelineConfigurator.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/BuildPipelineConfigurator.java
@@ -113,7 +113,15 @@ public class BuildPipelineConfigurator {
         ? appYaml.getRuntimeConfig()
         : new RuntimeConfig();
 
-    return new BuildContext(runtimeConfig, workspaceDir);
+    BuildContext buildContext = new BuildContext(runtimeConfig, workspaceDir);
+
+    // if the path to app.yaml is known, add it to the .gitignore
+    if (pathToAppYaml.isPresent()) {
+      Path relativeAppYamlPath = workspaceDir.relativize(pathToAppYaml.get());
+      buildContext.getDockerignore().appendLine(relativeAppYamlPath.toString());
+    }
+
+    return buildContext;
   }
 
   private AppYaml parseAppYaml(Path pathToAppYaml) throws IOException {

--- a/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/BuildPipelineConfiguratorTest.java
+++ b/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/BuildPipelineConfiguratorTest.java
@@ -45,7 +45,6 @@ import com.google.common.base.Objects;
 
 import com.google.common.io.Files;
 import java.nio.charset.Charset;
-import java.nio.file.Paths;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;

--- a/test/integration/tests/prebuilt-compat-app/structure.yaml
+++ b/test/integration/tests/prebuilt-compat-app/structure.yaml
@@ -11,3 +11,7 @@ fileExistenceTests:
   path: '/var/lib/jetty/webapps/root/WEB-INF/appengine-web.xml'
   isDirectory: false
   shouldExist: true
+- name: 'app.yaml file is not added to the application container'
+  path: '/var/lib/jetty/webapps/root/app.yaml'
+  isDirectory: false
+  shouldExist: false


### PR DESCRIPTION
Adds the path of an app.yaml file, if it exists, to the generated .dockerignore file.

fixes https://github.com/GoogleCloudPlatform/runtime-builder-java/issues/62