### PR TITLE
Add jdk:openjdk9 as a runtime lookup option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ section of this file tells the builder how to build and package your source. In 
 
 | Option Name | Type | Default | Description |
 |----------|------|---------|-------------|
-| jdk | string | openjdk8 | Select the JDK used in the generated image. Must be either `openjdk8` or `openjdk9`.
+| jdk | string | openjdk8 | Select the JDK used in the generated image. Must be either `openjdk8` or `openjdk9`. NOTE: `openjdk9` is not compatible with the `server` option (see below).
 | server | string | jetty | Select the web server to use in the generated image. Must be either `jetty9` or `tomcat8`
 | artifact | string |  Discovered based on the content of your build output | The path where the builder should expect to find the artifact to package in the resulting docker container. This setting will be required if your build produces more than one artifact. 
 | build_script | string | `mvn -B -DskipTests clean package` if a maven project is detected, or `gradle build` if a gradle project is detected | The build command that is executed to build your source |

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ section of this file tells the builder how to build and package your source. In 
 
 | Option Name | Type | Default | Description |
 |----------|------|---------|-------------|
-| jdk | string | openjdk8 | Select the JDK used in the generated image. The only supported value is `openjdk8`.
+| jdk | string | openjdk8 | Select the JDK used in the generated image. Must be either `openjdk8` or `openjdk9`.
 | server | string | jetty | Select the web server to use in the generated image. Must be either `jetty9` or `tomcat8`
 | artifact | string |  Discovered based on the content of your build output | The path where the builder should expect to find the artifact to package in the resulting docker container. This setting will be required if your build produces more than one artifact. 
 | build_script | string | `mvn -B -DskipTests clean package` if a maven project is detected, or `gradle build` if a gradle project is detected | The build command that is executed to build your source |

--- a/java.yaml
+++ b/java.yaml
@@ -23,6 +23,7 @@ steps:
   - '--jdk-runtimes-map'
   - '*=gcr.io/google-appengine/openjdk:8'
   - 'openjdk8=gcr.io/google-appengine/openjdk:8'
+  - 'openjdk9=gcr.io/google-appengine/openjdk:9'
 
   # Compat legacy runtime
   - '--compat-runtime-image=gcr.io/google-appengine/jetty9-compat:latest'


### PR DESCRIPTION
Adds openjdk9 as a lookup option via the `runtime_config.jdk field`. Note that since no other runtimes currently support java 9, the user will see an error if they combine this option with any of the `runtime_config.server` options, or attempt to deploy a WAR application while having this option selected.

Valid:
```yaml
env: flex
runtime: java
runtime_config:
  jdk: openjdk9
```

Invalid:
```yaml
env: flex
runtime: java
runtime_config:
  jdk: openjdk9
  server: jetty
```