### PR TITLE
Add support for beta_settings.enable_app_engine_apis

### DIFF
--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/BuildPipelineConfigurator.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/BuildPipelineConfigurator.java
@@ -25,7 +25,6 @@ import com.google.cloud.runtimes.builder.config.domain.AppYaml;
 import com.google.cloud.runtimes.builder.config.domain.BuildContext;
 import com.google.cloud.runtimes.builder.config.domain.BuildContextFactory;
 import com.google.cloud.runtimes.builder.config.domain.BuildTool;
-import com.google.cloud.runtimes.builder.config.domain.RuntimeConfig;
 import com.google.cloud.runtimes.builder.exception.AppYamlNotFoundException;
 import com.google.common.base.Strings;
 import com.google.inject.Inject;
@@ -108,18 +107,11 @@ public class BuildPipelineConfigurator {
     // locate and deserialize configuration files
     Optional<Path> pathToAppYaml = appYamlFinder.findAppYamlFile(workspaceDir);
 
-    AppYaml appYaml;
-    if (pathToAppYaml.isPresent()) {
-      appYaml = parseAppYaml(pathToAppYaml.get());
-    } else {
-      appYaml = new AppYaml();
-    }
+    AppYaml appYaml = pathToAppYaml.isPresent()
+        ? parseAppYaml(pathToAppYaml.get())
+        : new AppYaml();
 
-    RuntimeConfig runtimeConfig = appYaml.getRuntimeConfig() != null
-        ? appYaml.getRuntimeConfig()
-        : new RuntimeConfig();
-
-    BuildContext buildContext = buildContextFactory.createBuildContext(runtimeConfig, workspaceDir);
+    BuildContext buildContext = buildContextFactory.createBuildContext(appYaml, workspaceDir);
 
     // if the path to app.yaml is known, add it to the .gitignore
     if (pathToAppYaml.isPresent()) {

--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/buildsteps/PrebuiltRuntimeImageBuildStep.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/buildsteps/PrebuiltRuntimeImageBuildStep.java
@@ -50,13 +50,15 @@ public class PrebuiltRuntimeImageBuildStep extends RuntimeImageBuildStep {
 
     List<Path> artifacts;
     try {
-      // potential artifacts include all files at the root of the workspace and the workspace itself
-      Stream<Path> potentialArtifacts = Stream.concat(
-          Stream.of(buildContext.getWorkspaceDir()),
-          Files.list(buildContext.getWorkspaceDir()));
+      artifacts =
+          // potential artifacts include all files at the root of the workspace,
+          // and the workspace itself
+          Stream.concat(
+              Stream.of(buildContext.getWorkspaceDir()),
+              Files.list(buildContext.getWorkspaceDir())
+          )
 
-      // filter out non-valid artifacts
-      artifacts = potentialArtifacts
+          // filter out non-valid artifacts
           .filter(Artifact::isAnArtifact)
           .collect(Collectors.toList());
     } catch (IOException e) {

--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/buildsteps/RuntimeImageBuildStep.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/buildsteps/RuntimeImageBuildStep.java
@@ -71,7 +71,20 @@ public abstract class RuntimeImageBuildStep implements BuildStep {
       throws BuildStepException {
     RuntimeConfig runtimeConfig = buildContext.getRuntimeConfig();
 
-    // runtime type is selected based on the type of artifact
+    // Check if the user has explicitly selected the compat runtime
+    if (buildContext.isForceCompatRuntime()) {
+      if (artifact.getType() != APP_ENGINE_EXPLODED_WAR) {
+        throw new BuildStepException(String.format("The App Engine java-compat runtime requires an "
+            + "App Engine Exploded WAR artifact, but a %s artifact was provided (%s). In order to "
+            + "proceed, modify your application to build an App Engine exploded WAR artifact. "
+            + "See https://cloud.google.com/appengine/docs/flexible/java/upgrading for more "
+            + "detail.", artifact.getType().toString(), artifact.toString()));
+      }
+      logger.info("Using base image '{}' for App Engine exploded WAR artifact", compatImageName);
+      return compatImageName;
+    }
+
+    // Select runtime based on artifact type
 
     if (artifact.getPath().normalize().equals(buildContext.getWorkspaceDir())
         && artifact.getType() == APP_ENGINE_EXPLODED_WAR) {

--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/buildsteps/RuntimeImageBuildStep.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/buildsteps/RuntimeImageBuildStep.java
@@ -47,7 +47,7 @@ public abstract class RuntimeImageBuildStep implements BuildStep {
   @Override
   public void run(BuildContext buildContext) throws BuildStepException {
     Artifact artifact = getArtifact(buildContext);
-    logger.debug("Found Java artifact {}", artifact);
+    logger.debug("Identified Java artifact for deployment {}", artifact);
 
     buildContext.getDockerfile().appendLine("FROM " + getBaseRuntimeImage(buildContext, artifact));
     String copyStep = "COPY";
@@ -90,7 +90,7 @@ public abstract class RuntimeImageBuildStep implements BuildStep {
       // If the user expects a server to be involved, fail loudly.
       if (runtimeConfig.getServer() != null) {
         throw new BuildStepException("runtime_config.server configuration is not compatible with "
-            + ".jar artifacts. To use a web server runtime, use a .war artifact instead.");
+            + "JAR artifacts. To use a web server runtime, use a WAR artifact instead.");
       }
       String baseImage = jdkServerLookup.lookupJdkImage(runtimeConfig.getJdk());
       logger.info("Using base image '{}' for JAR artifact", baseImage);

--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/buildsteps/RuntimeImageBuildStep.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/buildsteps/RuntimeImageBuildStep.java
@@ -17,7 +17,6 @@
 package com.google.cloud.runtimes.builder.buildsteps;
 
 import static com.google.cloud.runtimes.builder.Constants.DOCKERFILE_BUILD_STAGE;
-import static com.google.cloud.runtimes.builder.config.domain.Artifact.ArtifactType.APP_ENGINE_EXPLODED_WAR;
 import static com.google.cloud.runtimes.builder.config.domain.Artifact.ArtifactType.EXPLODED_WAR;
 import static com.google.cloud.runtimes.builder.config.domain.Artifact.ArtifactType.JAR;
 import static com.google.cloud.runtimes.builder.config.domain.Artifact.ArtifactType.WAR;
@@ -73,21 +72,16 @@ public abstract class RuntimeImageBuildStep implements BuildStep {
     RuntimeConfig runtimeConfig = buildContext.getRuntimeConfig();
 
     // Check if the user has explicitly selected the compat runtime
-    if (buildContext.isForceCompatRuntime()) {
-      if (artifact.getType() != APP_ENGINE_EXPLODED_WAR) {
-        throw new BuildStepException(String.format("The App Engine java-compat runtime requires an "
-            + "App Engine Exploded WAR artifact, but a %s artifact was provided (%s). In order to "
-            + "proceed, modify your application to build an App Engine exploded WAR artifact. "
-            + "See https://cloud.google.com/appengine/docs/flexible/java/upgrading for more "
-            + "detail.", artifact.getType().toString(), artifact.toString()));
-      }
-      logger.info("Using base image '{}' for App Engine exploded WAR artifact", compatImageName);
-      return compatImageName;
+    if (buildContext.isCompatEnabled() && artifact.getType() != EXPLODED_WAR) {
+      throw new BuildStepException(String.format("App Engine APIs have been enabled. In order to "
+          + "use App Engine APIs, an exploded WAR artifact is required, but a %s artifact was "
+          + "found. See https://cloud.google.com/appengine/docs/flexible/java/upgrading for more "
+          + "detail.", artifact.getType()));
     }
 
     // Select runtime based on artifact type
 
-    if (artifact.getType() == APP_ENGINE_EXPLODED_WAR || artifact.getType() == EXPLODED_WAR) {
+    if (artifact.getType() == EXPLODED_WAR) {
       // Use the compat runtime for exploded war artifacts.
       logger.info("Using base image '{}' for exploded WAR artifact", compatImageName);
       return compatImageName;

--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/config/AppYamlParser.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/config/AppYamlParser.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
+import com.google.cloud.runtimes.builder.config.domain.BetaSettings;
+import com.google.cloud.runtimes.builder.config.domain.RuntimeConfig;
 import java.io.IOException;
 import java.nio.file.Path;
 
@@ -42,7 +44,13 @@ public class AppYamlParser implements YamlParser<AppYaml> {
 
   @Override
   public AppYaml parse(Path yamlFilePath) throws IOException {
-    // TODO validation logic
-    return objectMapper.readValue(yamlFilePath.toFile(), AppYaml.class);
+    AppYaml appYaml = objectMapper.readValue(yamlFilePath.toFile(), AppYaml.class);
+    if (appYaml.getBetaSettings() == null) {
+      appYaml.setBetaSettings(new BetaSettings());
+    }
+    if (appYaml.getRuntimeConfig() == null) {
+     appYaml.setRuntimeConfig(new RuntimeConfig());
+    }
+    return appYaml;
   }
 }

--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/config/AppYamlParser.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/config/AppYamlParser.java
@@ -17,13 +17,13 @@
 package com.google.cloud.runtimes.builder.config;
 
 import com.google.cloud.runtimes.builder.config.domain.AppYaml;
+import com.google.cloud.runtimes.builder.config.domain.BetaSettings;
+import com.google.cloud.runtimes.builder.config.domain.RuntimeConfig;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
-import com.google.cloud.runtimes.builder.config.domain.BetaSettings;
-import com.google.cloud.runtimes.builder.config.domain.RuntimeConfig;
 import java.io.IOException;
 import java.nio.file.Path;
 
@@ -49,7 +49,7 @@ public class AppYamlParser implements YamlParser<AppYaml> {
       appYaml.setBetaSettings(new BetaSettings());
     }
     if (appYaml.getRuntimeConfig() == null) {
-     appYaml.setRuntimeConfig(new RuntimeConfig());
+      appYaml.setRuntimeConfig(new RuntimeConfig());
     }
     return appYaml;
   }

--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/config/domain/Artifact.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/config/domain/Artifact.java
@@ -24,7 +24,7 @@ import java.nio.file.Path;
 public class Artifact {
 
   public enum ArtifactType {
-    JAR, WAR, EXPLODED_WAR, APP_ENGINE_EXPLODED_WAR
+    JAR, WAR, EXPLODED_WAR
   }
 
   private final Path path;
@@ -66,10 +66,7 @@ public class Artifact {
   public static Artifact fromPath(Path path) {
     String extension = com.google.common.io.Files.getFileExtension(path.toString());
 
-    if (Files.exists(path.resolve("WEB-INF").resolve("appengine-web.xml"))) {
-      return new Artifact(ArtifactType.APP_ENGINE_EXPLODED_WAR, path);
-
-    } else if (Files.exists(path.resolve("WEB-INF"))) {
+    if (Files.exists(path.resolve("WEB-INF"))) {
       return new Artifact(ArtifactType.EXPLODED_WAR, path);
 
     } else if (extension.equalsIgnoreCase("war")) {

--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/config/domain/BetaSettings.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/config/domain/BetaSettings.java
@@ -20,26 +20,16 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class AppYaml {
+public class BetaSettings {
 
-  private RuntimeConfig runtimeConfig = new RuntimeConfig();
-  private BetaSettings betaSettings = new BetaSettings();
+  private boolean enableAppEngineApis = false;
 
-  @JsonProperty("runtime_config")
-  public RuntimeConfig getRuntimeConfig() {
-    return runtimeConfig;
+  public boolean isEnableAppEngineApis() {
+    return enableAppEngineApis;
   }
 
-  public void setRuntimeConfig(RuntimeConfig runtimeConfig) {
-    this.runtimeConfig = runtimeConfig;
-  }
-
-  @JsonProperty("beta_settings")
-  public BetaSettings getBetaSettings() {
-    return betaSettings;
-  }
-
-  public void setBetaSettings(BetaSettings betaSettings) {
-    this.betaSettings = betaSettings;
+  @JsonProperty("enable_app_engine_apis")
+  public void setEnableAppEngineApis(boolean enableAppEngineApis) {
+    this.enableAppEngineApis = enableAppEngineApis;
   }
 }

--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/config/domain/BuildContext.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/config/domain/BuildContext.java
@@ -126,7 +126,7 @@ public class BuildContext {
    *
    * @return true if the user has explicitly requested a compat runtime
    */
-  public boolean isForceCompatRuntime() {
+  public boolean isCompatEnabled() {
     return appYaml.getBetaSettings().isEnableAppEngineApis();
   }
 

--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/config/domain/BuildContext.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/config/domain/BuildContext.java
@@ -53,7 +53,7 @@ public class BuildContext {
 
   private final Logger logger = LoggerFactory.getLogger(BuildContext.class);
 
-  private final RuntimeConfig runtimeConfig;
+  private final AppYaml appYaml;
   private final Path workspaceDir;
   private final StringLineAppender dockerfile;
   private final StringLineAppender dockerignore;
@@ -64,16 +64,17 @@ public class BuildContext {
   /**
    * Constructs a new {@link BuildContext}.
    *
-   * @param runtimeConfig runtime configuration object provided by the user
+   * @param appYaml configuration object provided by the user
    * @param workspaceDir the directory in which the build will take place
+   * @param disableSourceBuild whether or not source builds should be disabled
    */
   @Inject
   @VisibleForTesting
-  public BuildContext(@Assisted RuntimeConfig runtimeConfig, @Assisted Path workspaceDir,
+  public BuildContext(@Assisted AppYaml appYaml, @Assisted Path workspaceDir,
       @DisableSourceBuild boolean disableSourceBuild) {
     Preconditions.checkArgument(Files.isDirectory(workspaceDir));
 
-    this.runtimeConfig = runtimeConfig;
+    this.appYaml = appYaml;
     this.workspaceDir = workspaceDir;
     this.dockerfile = new StringLineAppender();
     // dockerignore should always include itself and the dockerfile
@@ -84,7 +85,7 @@ public class BuildContext {
   }
 
   public RuntimeConfig getRuntimeConfig() {
-    return runtimeConfig;
+    return appYaml.getRuntimeConfig();
   }
 
   public Path getWorkspaceDir() {
@@ -113,8 +114,8 @@ public class BuildContext {
    */
   public boolean isSourceBuild() {
     try {
-      return !disableSourceBuild && (!Strings.isNullOrEmpty(runtimeConfig.getBuildScript())
-          || getBuildTool().isPresent());
+      return !disableSourceBuild && (!Strings.isNullOrEmpty(
+          appYaml.getRuntimeConfig().getBuildScript()) || getBuildTool().isPresent());
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -126,8 +127,7 @@ public class BuildContext {
    * @return true if the user has explicitly requested a compat runtime
    */
   public boolean isForceCompatRuntime() {
-    return runtimeConfig.getBetaSettings() != null
-        && runtimeConfig.getBetaSettings().isEnableAppEngineApis();
+    return appYaml.getBetaSettings().isEnableAppEngineApis();
   }
 
   /**

--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/config/domain/BuildContext.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/config/domain/BuildContext.java
@@ -121,6 +121,16 @@ public class BuildContext {
   }
 
   /**
+   * Returns whether or not a compat runtime was requested in the user's configuration.
+   *
+   * @return true if the user has explicitly requested a compat runtime
+   */
+  public boolean isForceCompatRuntime() {
+    return runtimeConfig.getBetaSettings() != null
+        && runtimeConfig.getBetaSettings().isEnableAppEngineApis();
+  }
+
+  /**
    * Writes the contents of Dockerfile and .dockerignore buffers to files. If a .dockerignore file
    * already exists, the .dockerignore buffer will be appended to it.
    *

--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/config/domain/BuildContextFactory.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/config/domain/BuildContextFactory.java
@@ -25,6 +25,6 @@ import java.nio.file.Path;
  */
 public interface BuildContextFactory {
 
-  BuildContext createBuildContext(RuntimeConfig runtimeConfig, Path workspaceDir);
+  BuildContext createBuildContext(AppYaml appYaml, Path workspaceDir);
 
 }

--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/config/domain/RuntimeConfig.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/config/domain/RuntimeConfig.java
@@ -26,8 +26,7 @@ public class RuntimeConfig {
   private String server;
   private String buildScript;
   private String artifact;
-  private boolean jettyQuickstart = false;
-  private BetaSettings betaSettings = new BetaSettings();
+  private boolean jettyQuickstart;
 
   public String getJdk() {
     return jdk;
@@ -69,28 +68,5 @@ public class RuntimeConfig {
   @JsonProperty("jetty_quickstart")
   public void setJettyQuickstart(boolean jettyQuickstart) {
     this.jettyQuickstart = jettyQuickstart;
-  }
-
-  public BetaSettings getBetaSettings() {
-    return betaSettings;
-  }
-
-  @JsonProperty("beta_settings")
-  public void setBetaSettings(BetaSettings betaSettings) {
-    this.betaSettings = betaSettings;
-  }
-
-  @JsonIgnoreProperties(ignoreUnknown = true)
-  public static class BetaSettings {
-    private boolean enableAppEngineApis = false;
-
-    public boolean isEnableAppEngineApis() {
-      return enableAppEngineApis;
-    }
-
-    @JsonProperty("enable_app_engine_apis")
-    public void setEnableAppEngineApis(boolean enableAppEngineApis) {
-      this.enableAppEngineApis = enableAppEngineApis;
-    }
   }
 }

--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/config/domain/RuntimeConfig.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/config/domain/RuntimeConfig.java
@@ -81,7 +81,7 @@ public class RuntimeConfig {
   }
 
   @JsonIgnoreProperties(ignoreUnknown = true)
-  static class BetaSettings {
+  public static class BetaSettings {
     private boolean enableAppEngineApis = false;
 
     public boolean isEnableAppEngineApis() {

--- a/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/config/domain/RuntimeConfig.java
+++ b/java-runtime-builder-app/src/main/java/com/google/cloud/runtimes/builder/config/domain/RuntimeConfig.java
@@ -26,7 +26,8 @@ public class RuntimeConfig {
   private String server;
   private String buildScript;
   private String artifact;
-  private boolean jettyQuickstart;
+  private boolean jettyQuickstart = false;
+  private BetaSettings betaSettings = new BetaSettings();
 
   public String getJdk() {
     return jdk;
@@ -68,5 +69,28 @@ public class RuntimeConfig {
   @JsonProperty("jetty_quickstart")
   public void setJettyQuickstart(boolean jettyQuickstart) {
     this.jettyQuickstart = jettyQuickstart;
+  }
+
+  public BetaSettings getBetaSettings() {
+    return betaSettings;
+  }
+
+  @JsonProperty("beta_settings")
+  public void setBetaSettings(BetaSettings betaSettings) {
+    this.betaSettings = betaSettings;
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  static class BetaSettings {
+    private boolean enableAppEngineApis = false;
+
+    public boolean isEnableAppEngineApis() {
+      return enableAppEngineApis;
+    }
+
+    @JsonProperty("enable_app_engine_apis")
+    public void setEnableAppEngineApis(boolean enableAppEngineApis) {
+      this.enableAppEngineApis = enableAppEngineApis;
+    }
   }
 }

--- a/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/buildsteps/JettyOptionsBuildStepTest.java
+++ b/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/buildsteps/JettyOptionsBuildStepTest.java
@@ -4,6 +4,7 @@ import static junit.framework.TestCase.assertEquals;
 
 import com.google.cloud.runtimes.builder.TestUtils.TestWorkspaceBuilder;
 import com.google.cloud.runtimes.builder.buildsteps.base.BuildStepException;
+import com.google.cloud.runtimes.builder.config.domain.AppYaml;
 import com.google.cloud.runtimes.builder.config.domain.BuildContext;
 import com.google.cloud.runtimes.builder.config.domain.RuntimeConfig;
 import java.io.IOException;
@@ -42,7 +43,9 @@ public class JettyOptionsBuildStepTest {
   }
 
   private BuildContext initBuildContext(RuntimeConfig runtimeConfig) throws IOException {
-    return new BuildContext(runtimeConfig, new TestWorkspaceBuilder().build(), false);
+    AppYaml appYaml = new AppYaml();
+    appYaml.setRuntimeConfig(runtimeConfig);
+    return new BuildContext(appYaml, new TestWorkspaceBuilder().build(), false);
   }
 
 }

--- a/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/buildsteps/PrebuiltRuntimeImageBuildStepTest.java
+++ b/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/buildsteps/PrebuiltRuntimeImageBuildStepTest.java
@@ -2,7 +2,6 @@ package com.google.cloud.runtimes.builder.buildsteps;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -183,13 +182,11 @@ public class PrebuiltRuntimeImageBuildStepTest {
         .build();
     BuildContext buildContext = new BuildContext(new AppYaml(), workspace, false);
 
-    String serverRuntime = "server-runtime";
-    when(jdkServerLookup.lookupServerImage(isNull(), isNull())).thenReturn(serverRuntime);
     prebuiltRuntimeImageBuildStep.run(buildContext);
 
     String dockerfile = buildContext.getDockerfile().toString();
-    assertTrue(dockerfile.startsWith("FROM " + serverRuntime + "\n"));
-    assertTrue(dockerfile.contains("COPY ./ $APP_DESTINATION"));
+    assertTrue(dockerfile.startsWith("FROM " + compatImageName + "\n"));
+    assertTrue(dockerfile.contains("COPY ./ /app/"));
   }
 
   @Test
@@ -203,8 +200,8 @@ public class PrebuiltRuntimeImageBuildStepTest {
     prebuiltRuntimeImageBuildStep.run(buildContext);
     String dockerfile = buildContext.getDockerfile().toString();
 
-    assertTrue(dockerfile.startsWith("FROM " + serverRuntime));
-    assertTrue(dockerfile.contains("COPY " + "./foo.war $APP_DESTINATION"));
+    assertTrue(dockerfile.startsWith("FROM " + compatImageName));
+    assertTrue(dockerfile.contains("COPY " + "./foo.war /app/"));
   }
 
   @Test(expected = BuildStepException.class)

--- a/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/buildsteps/PrebuiltRuntimeImageBuildStepTest.java
+++ b/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/buildsteps/PrebuiltRuntimeImageBuildStepTest.java
@@ -8,10 +8,11 @@ import static org.mockito.Mockito.when;
 
 import com.google.cloud.runtimes.builder.TestUtils.TestWorkspaceBuilder;
 import com.google.cloud.runtimes.builder.buildsteps.base.BuildStepException;
+import com.google.cloud.runtimes.builder.config.domain.AppYaml;
+import com.google.cloud.runtimes.builder.config.domain.BetaSettings;
 import com.google.cloud.runtimes.builder.config.domain.BuildContext;
 import com.google.cloud.runtimes.builder.config.domain.JdkServerLookup;
 import com.google.cloud.runtimes.builder.config.domain.RuntimeConfig;
-import com.google.cloud.runtimes.builder.config.domain.RuntimeConfig.BetaSettings;
 import com.google.cloud.runtimes.builder.exception.ArtifactNotFoundException;
 import com.google.cloud.runtimes.builder.exception.TooManyArtifactsException;
 import java.io.IOException;
@@ -46,7 +47,9 @@ public class PrebuiltRuntimeImageBuildStepTest {
     String configuredArtifactPath = "artifactDir/my_artifact.jar";
     RuntimeConfig runtimeConfig = new RuntimeConfig();
     runtimeConfig.setArtifact(configuredArtifactPath);
-    BuildContext buildContext = new BuildContext(runtimeConfig, workspace, false);
+    AppYaml appYaml = new AppYaml();
+    appYaml.setRuntimeConfig(runtimeConfig);
+    BuildContext buildContext = new BuildContext(appYaml, workspace, false);
 
     String image = "test_image";
     when(jdkServerLookup.lookupJdkImage(null)).thenReturn(image);
@@ -65,7 +68,7 @@ public class PrebuiltRuntimeImageBuildStepTest {
         .file("bar.war").build()
         .build();
 
-    BuildContext buildContext = new BuildContext(new RuntimeConfig(), workspace, false);
+    BuildContext buildContext = new BuildContext(new AppYaml(), workspace, false);
     prebuiltRuntimeImageBuildStep.run(buildContext);
   }
 
@@ -76,7 +79,7 @@ public class PrebuiltRuntimeImageBuildStepTest {
         .file("foo.war/WEB-INF/web.xml").build()
         .build();
 
-    BuildContext buildContext = new BuildContext(new RuntimeConfig(), workspace, false);
+    BuildContext buildContext = new BuildContext(new AppYaml(), workspace, false);
     prebuiltRuntimeImageBuildStep.run(buildContext);
   }
 
@@ -86,7 +89,7 @@ public class PrebuiltRuntimeImageBuildStepTest {
         .file("foo.war").build()
         .build();
 
-    BuildContext buildContext = new BuildContext(new RuntimeConfig(), workspace, false);
+    BuildContext buildContext = new BuildContext(new AppYaml(), workspace, false);
     String image = "test_war_image";
     when(jdkServerLookup.lookupServerImage(null, null)).thenReturn(image);
 
@@ -104,7 +107,9 @@ public class PrebuiltRuntimeImageBuildStepTest {
 
     RuntimeConfig runtimeConfig = new RuntimeConfig();
     runtimeConfig.setJdk("custom_jdk");
-    BuildContext buildContext = new BuildContext(runtimeConfig, workspace, false);
+    AppYaml appYaml = new AppYaml();
+    appYaml.setRuntimeConfig(runtimeConfig);
+    BuildContext buildContext = new BuildContext(appYaml, workspace, false);
 
     String image = "custom_jdk_image";
     when(jdkServerLookup.lookupJdkImage("custom_jdk")).thenReturn(image);
@@ -125,7 +130,9 @@ public class PrebuiltRuntimeImageBuildStepTest {
     RuntimeConfig runtimeConfig = new RuntimeConfig();
     runtimeConfig.setJdk("custom_jdk");
     runtimeConfig.setServer("custom_server");
-    BuildContext buildContext = new BuildContext(runtimeConfig, workspace, false);
+    AppYaml appYaml = new AppYaml();
+    appYaml.setRuntimeConfig(runtimeConfig);
+    BuildContext buildContext = new BuildContext(appYaml, workspace, false);
 
     assertEquals(workspace.resolve("foo.jar"), prebuiltRuntimeImageBuildStep.getArtifact(buildContext).getPath());
 
@@ -135,7 +142,7 @@ public class PrebuiltRuntimeImageBuildStepTest {
   @Test(expected = ArtifactNotFoundException.class)
   public void testNoArtifacts() throws IOException, BuildStepException {
     Path workspace = new TestWorkspaceBuilder().build();
-    BuildContext buildContext = new BuildContext(new RuntimeConfig(), workspace, false);
+    BuildContext buildContext = new BuildContext(new AppYaml(), workspace, false);
     prebuiltRuntimeImageBuildStep.run(buildContext);
   }
 
@@ -161,7 +168,7 @@ public class PrebuiltRuntimeImageBuildStepTest {
         .file("WEB-INF/appengine-web.xml").build()
         .file("WEB-INF/web.xml").build()
         .build();
-    BuildContext buildContext = new BuildContext(new RuntimeConfig(), workspace, false);
+    BuildContext buildContext = new BuildContext(new AppYaml(), workspace, false);
     prebuiltRuntimeImageBuildStep.run(buildContext);
 
     String dockerfile = buildContext.getDockerfile().toString();
@@ -174,7 +181,7 @@ public class PrebuiltRuntimeImageBuildStepTest {
     Path workspace = new TestWorkspaceBuilder()
         .file("WEB-INF/web.xml").build()
         .build();
-    BuildContext buildContext = new BuildContext(new RuntimeConfig(), workspace, false);
+    BuildContext buildContext = new BuildContext(new AppYaml(), workspace, false);
 
     String serverRuntime = "server-runtime";
     when(jdkServerLookup.lookupServerImage(isNull(), isNull())).thenReturn(serverRuntime);
@@ -192,7 +199,7 @@ public class PrebuiltRuntimeImageBuildStepTest {
     Path workspace = new TestWorkspaceBuilder()
         .file("foo.war/WEB-INF/web.xml").build()
         .build();
-    BuildContext buildContext = new BuildContext(new RuntimeConfig(), workspace, false);
+    BuildContext buildContext = new BuildContext(new AppYaml(), workspace, false);
     prebuiltRuntimeImageBuildStep.run(buildContext);
     String dockerfile = buildContext.getDockerfile().toString();
 
@@ -208,9 +215,9 @@ public class PrebuiltRuntimeImageBuildStepTest {
 
     BetaSettings betaSettings = new BetaSettings();
     betaSettings.setEnableAppEngineApis(true);
-    RuntimeConfig runtimeConfig = new RuntimeConfig();
-    runtimeConfig.setBetaSettings(betaSettings);
-    BuildContext buildContext = new BuildContext(runtimeConfig, workspace, false);
+    AppYaml appYaml = new AppYaml();
+    appYaml.setBetaSettings(betaSettings);
+    BuildContext buildContext = new BuildContext(appYaml, workspace, false);
 
     prebuiltRuntimeImageBuildStep.run(buildContext);
   }
@@ -224,9 +231,9 @@ public class PrebuiltRuntimeImageBuildStepTest {
 
     BetaSettings betaSettings = new BetaSettings();
     betaSettings.setEnableAppEngineApis(true);
-    RuntimeConfig runtimeConfig = new RuntimeConfig();
-    runtimeConfig.setBetaSettings(betaSettings);
-    BuildContext buildContext = new BuildContext(runtimeConfig, workspace, false);
+    AppYaml appYaml = new AppYaml();
+    appYaml.setBetaSettings(betaSettings);
+    BuildContext buildContext = new BuildContext(appYaml, workspace, false);
 
     prebuiltRuntimeImageBuildStep.run(buildContext);
 

--- a/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/buildsteps/SourceBuildRuntimeImageBuildStepTest.java
+++ b/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/buildsteps/SourceBuildRuntimeImageBuildStepTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.cloud.runtimes.builder.TestUtils.TestWorkspaceBuilder;
 import com.google.cloud.runtimes.builder.buildsteps.base.BuildStepException;
+import com.google.cloud.runtimes.builder.config.domain.AppYaml;
 import com.google.cloud.runtimes.builder.config.domain.BuildContext;
 import com.google.cloud.runtimes.builder.config.domain.JdkServerLookup;
 import com.google.cloud.runtimes.builder.config.domain.RuntimeConfig;
@@ -46,7 +47,9 @@ public class SourceBuildRuntimeImageBuildStepTest {
   }
 
   private BuildContext initBuildContext() throws IOException {
-    return new BuildContext(runtimeConfig, new TestWorkspaceBuilder().build(), false);
+    AppYaml appYaml = new AppYaml();
+    appYaml.setRuntimeConfig(runtimeConfig);
+    return new BuildContext(appYaml, new TestWorkspaceBuilder().build(), false);
   }
 
   @Test(expected = IllegalStateException.class)

--- a/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/config/AppYamlParserTest.java
+++ b/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/config/AppYamlParserTest.java
@@ -17,6 +17,7 @@
 package com.google.cloud.runtimes.builder.config;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -61,15 +62,63 @@ public class AppYamlParserTest {
   @Test
   public void testParse_defaultAppYaml() throws IOException {
     AppYaml result = parseFileWithContents(APP_YAML_PREAMBLE);
+
     assertNotNull(result.getRuntimeConfig());
     assertNotNull(result.getBetaSettings());
+
+    assertNull(result.getRuntimeConfig().getServer());
+    assertFalse(result.getRuntimeConfig().getJettyQuickstart());
+    assertNull(result.getRuntimeConfig().getBuildScript());
+    assertNull(result.getRuntimeConfig().getArtifact());
+    assertNull(result.getRuntimeConfig().getJdk());
+
+    assertFalse(result.getBetaSettings().isEnableAppEngineApis());
+  }
+
+  @Test
+  public void testParseEnableAppEngineApisFalse() throws IOException {
+    AppYaml result = parseFileWithContents(APP_YAML_PREAMBLE
+        + "beta_settings:\n"
+        + "  enable_app_engine_apis: false");
+    assertFalse(result.getBetaSettings().isEnableAppEngineApis());
+  }
+
+  @Test
+  public void testParseEnableAppEngineApisUpperFalse() throws IOException {
+    AppYaml result = parseFileWithContents(APP_YAML_PREAMBLE
+        + "beta_settings:\n"
+        + "  enable_app_engine_apis: False");
+    assertFalse(result.getBetaSettings().isEnableAppEngineApis());
+  }
+
+  @Test
+  public void testParseEnableAppEngineApisTrue() throws IOException {
+    AppYaml result = parseFileWithContents(APP_YAML_PREAMBLE
+        + "beta_settings:\n"
+        + "  enable_app_engine_apis: true");
+    assertTrue(result.getBetaSettings().isEnableAppEngineApis());
+  }
+
+  @Test
+  public void testParseEnableAppEngineApisUpperTrue() throws IOException {
+    AppYaml result = parseFileWithContents(APP_YAML_PREAMBLE
+        + "beta_settings:\n"
+        + "  enable_app_engine_apis: True");
+    assertTrue(result.getBetaSettings().isEnableAppEngineApis());
+  }
+
+  @Test
+  public void testParseEmptyBetaSettings() throws IOException {
+    AppYaml result = parseFileWithContents(APP_YAML_PREAMBLE
+        + "beta_settings:\n");
+    assertFalse(result.getBetaSettings().isEnableAppEngineApis());
   }
 
   @Test
   public void testParse_emptyRuntimeConfig() throws IOException {
     AppYaml result = parseFileWithContents(APP_YAML_PREAMBLE
         + "runtime_config:\n");
-    assertNull(result.getRuntimeConfig());
+    assertNotNull(result.getRuntimeConfig());
   }
 
   @Test

--- a/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/config/AppYamlParserTest.java
+++ b/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/config/AppYamlParserTest.java
@@ -17,11 +17,13 @@
 package com.google.cloud.runtimes.builder.config;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.runtimes.builder.config.domain.AppYaml;
 
+import com.google.cloud.runtimes.builder.config.domain.RuntimeConfig;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -60,7 +62,8 @@ public class AppYamlParserTest {
   @Test
   public void testParse_defaultAppYaml() throws IOException {
     AppYaml result = parseFileWithContents(APP_YAML_PREAMBLE);
-    assertNull(result.getRuntimeConfig());
+    assertNotNull(result.getRuntimeConfig());
+    assertNotNull(result.getBetaSettings());
   }
 
   @Test

--- a/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/config/AppYamlParserTest.java
+++ b/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/config/AppYamlParserTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.runtimes.builder.config.domain.AppYaml;
 
-import com.google.cloud.runtimes.builder.config.domain.RuntimeConfig;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/config/domain/ArtifactTest.java
+++ b/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/config/domain/ArtifactTest.java
@@ -1,6 +1,5 @@
 package com.google.cloud.runtimes.builder.config.domain;
 
-import static com.google.cloud.runtimes.builder.config.domain.Artifact.ArtifactType.APP_ENGINE_EXPLODED_WAR;
 import static com.google.cloud.runtimes.builder.config.domain.Artifact.ArtifactType.EXPLODED_WAR;
 import static com.google.cloud.runtimes.builder.config.domain.Artifact.ArtifactType.JAR;
 import static com.google.cloud.runtimes.builder.config.domain.Artifact.ArtifactType.WAR;
@@ -75,7 +74,7 @@ public class ArtifactTest {
 
     Artifact result = Artifact.fromPath(path);
     assertEquals(path, result.getPath());
-    assertEquals(APP_ENGINE_EXPLODED_WAR, result.getType());
+    assertEquals(EXPLODED_WAR, result.getType());
   }
 
   @Test

--- a/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/config/domain/BuildContextTest.java
+++ b/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/config/domain/BuildContextTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.runtimes.builder.TestUtils.TestWorkspaceBuilder;
-import com.google.cloud.runtimes.builder.config.domain.RuntimeConfig.BetaSettings;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -20,6 +19,7 @@ public class BuildContextTest {
 
   private Path workspace;
   private RuntimeConfig runtimeConfig;
+  private BetaSettings betaSettings;
   private boolean disableSourceBuild;
 
   private static final String DOCKER_IGNORE_PREAMBLE = "Dockerfile\n"
@@ -30,11 +30,15 @@ public class BuildContextTest {
     // initialize to empty dir
     workspace = new TestWorkspaceBuilder().build();
     runtimeConfig = new RuntimeConfig();
+    betaSettings = new BetaSettings();
     disableSourceBuild = false;
   }
 
   private BuildContext initBuildContext() {
-    return new BuildContext(runtimeConfig, workspace, disableSourceBuild);
+    AppYaml appYaml = new AppYaml();
+    appYaml.setRuntimeConfig(runtimeConfig);
+    appYaml.setBetaSettings(betaSettings);
+    return new BuildContext(appYaml, workspace, disableSourceBuild);
   }
 
   @Test
@@ -161,24 +165,14 @@ public class BuildContextTest {
   }
 
   @Test
-  public void testIsForceCompatRuntimeWithNullBetaSettings() {
-    runtimeConfig.setBetaSettings(null);
-    assertFalse(initBuildContext().isForceCompatRuntime());
-  }
-
-  @Test
   public void testIsForceCompatRuntimeWithBetaSettingsFalse() {
-    BetaSettings betaSettings = new BetaSettings();
     betaSettings.setEnableAppEngineApis(false);
-    runtimeConfig.setBetaSettings(betaSettings);
     assertFalse(initBuildContext().isForceCompatRuntime());
   }
 
   @Test
   public void testIsForceCompatRuntimeWithBetaSettingsTrue() {
-    BetaSettings betaSettings = new BetaSettings();
     betaSettings.setEnableAppEngineApis(true);
-    runtimeConfig.setBetaSettings(betaSettings);
     assertTrue(initBuildContext().isForceCompatRuntime());
   }
 

--- a/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/config/domain/BuildContextTest.java
+++ b/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/config/domain/BuildContextTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.runtimes.builder.TestUtils.TestWorkspaceBuilder;
+import com.google.cloud.runtimes.builder.config.domain.RuntimeConfig.BetaSettings;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -157,6 +158,28 @@ public class BuildContextTest {
 
     assertEquals(BuildTool.GRADLE,
         initBuildContext().getBuildTool().get());
+  }
+
+  @Test
+  public void testIsForceCompatRuntimeWithNullBetaSettings() {
+    runtimeConfig.setBetaSettings(null);
+    assertFalse(initBuildContext().isForceCompatRuntime());
+  }
+
+  @Test
+  public void testIsForceCompatRuntimeWithBetaSettingsFalse() {
+    BetaSettings betaSettings = new BetaSettings();
+    betaSettings.setEnableAppEngineApis(false);
+    runtimeConfig.setBetaSettings(betaSettings);
+    assertFalse(initBuildContext().isForceCompatRuntime());
+  }
+
+  @Test
+  public void testIsForceCompatRuntimeWithBetaSettingsTrue() {
+    BetaSettings betaSettings = new BetaSettings();
+    betaSettings.setEnableAppEngineApis(true);
+    runtimeConfig.setBetaSettings(betaSettings);
+    assertTrue(initBuildContext().isForceCompatRuntime());
   }
 
   private Path getDockerfile() {

--- a/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/config/domain/BuildContextTest.java
+++ b/java-runtime-builder-app/src/test/java/com/google/cloud/runtimes/builder/config/domain/BuildContextTest.java
@@ -167,13 +167,13 @@ public class BuildContextTest {
   @Test
   public void testIsForceCompatRuntimeWithBetaSettingsFalse() {
     betaSettings.setEnableAppEngineApis(false);
-    assertFalse(initBuildContext().isForceCompatRuntime());
+    assertFalse(initBuildContext().isCompatEnabled());
   }
 
   @Test
   public void testIsForceCompatRuntimeWithBetaSettingsTrue() {
     betaSettings.setEnableAppEngineApis(true);
-    assertTrue(initBuildContext().isForceCompatRuntime());
+    assertTrue(initBuildContext().isCompatEnabled());
   }
 
   private Path getDockerfile() {


### PR DESCRIPTION
Adds support for the `beta_settings.enable_app_engine_apis` setting. If set to "true", the builder will treat this setting as forcing the use of a compat runtime. 

fixes #47