### PR TITLE
Use gcr.io/cloud-builders/mvn and /gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ docker run -v $LOCAL_APPLICATION_DIR:/workspace -w /workspace runtime-builder \
     --jdk-runtimes-map='*=gcr.io/google-appengine/openjdk:8' \
     --server-runtimes-map='*|*=gcr.io/google-appengine/jetty:9' \
     --compat-docker-image='gcr.io/google-appengine/jetty9-compat' \
-    --maven-docker-image='gcr.io/cloud-builders/java/mvn:3.5.0-jdk-8' \
-    --gradle-docker-image='gcr.io/cloud-builders/java/gradle:4.0-jdk-8'
+    --maven-docker-image='gcr.io/cloud-builders/mvn:3.5.0-jdk-8' \
+    --gradle-docker-image='gcr.io/cloud-builders/gradle:4.0-jdk-8'
 
 # package my application into a docker container
 docker build -t my-app-container $LOCAL_APPLICATION_DIR

--- a/java-runtime-builder-docker/src/main/resources/docker/Dockerfile
+++ b/java-runtime-builder-docker/src/main/resources/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/cloud-builders/java/mvn:3.5.0-jdk-8
+FROM gcr.io/cloud-builders/mvn:3.5.0-jdk-8
 
 ARG GRADLE_VERSION=3.4
 

--- a/java.yaml
+++ b/java.yaml
@@ -28,10 +28,10 @@ steps:
   - '--compat-runtime-image=gcr.io/google-appengine/jetty9-compat:latest'
 
   # Image to use for maven builds
-  - '--maven-docker-image=gcr.io/cloud-builders/java/mvn:3.5.0-jdk-8'
+  - '--maven-docker-image=gcr.io/cloud-builders/mvn:3.5.0-jdk-8'
 
   # Image to use for gradle builds
-  - '--gradle-docker-image=gcr.io/cloud-builders/java/gradle:4.0-jdk-8'
+  - '--gradle-docker-image=gcr.io/cloud-builders/gradle:4.0-jdk-8'
 
   # Disable building from source
   # FIXME: https://github.com/GoogleCloudPlatform/runtime-builder-java/milestone/2

--- a/scripts/pipeline-cloudbuild.yaml
+++ b/scripts/pipeline-cloudbuild.yaml
@@ -3,7 +3,7 @@
 
 steps:
 # Build the maven project, omitting the docker build step
-- name: 'gcr.io/cloud-builders/java/mvn:3.5.0-jdk-8'
+- name: 'gcr.io/cloud-builders/mvn:3.5.0-jdk-8'
   args: ['-B', '-P-local-docker-build', 'clean', 'install']
   id: 'MAVEN'
 


### PR DESCRIPTION
This is a purely cosmetic change, but we now prefer the top-level image name rather than the java-namespaced name.