### PR TITLE
Fix class loader for surefire.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,13 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <useSystemClassLoader>false</useSystemClassLoader>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Builds started failing with: Step #1 - "MAVEN": Error: Could not find or load main class org.apache.maven.surefire.booter.ForkedBooter