### PR TITLE
Revert "Update Builder Structure Tests"

### DIFF
--- a/test/structure/structure.yaml
+++ b/test/structure/structure.yaml
@@ -20,9 +20,9 @@ commandTests:
   command: ['javac', '-version']
   expectedError: ['javac 1\.8\.0_.+']
   exitCode: '0'
-- name: 'M2_HOME is set'
+- name: 'MAVEN_HOME is set'
   command: ['env']
-  expectedOutput: ['M2_HOME=/usr/share/maven']
+  expectedOutput: ['MAVEN_HOME=/usr/share/maven']
 - name: 'GRADLE_HOME is set'
   command: ['env']
   expectedOutput: ['GRADLE_HOME=/usr/share/gradle-3.4']


### PR DESCRIPTION
Reverts GoogleCloudPlatform/runtime-builder-java#65

As seen below the current version of the base image `gcr.io/cloud-builders/mvn:3.5.0-jdk-8` has the variable named as `MAVEN_HOME`.

```bash
$ docker run --rm --entrypoint=printenv gcr.io/cloud-builders/mvn:3.5.0-jdk-8
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
HOSTNAME=ede55c26c493
LANG=C.UTF-8
JAVA_HOME=/docker-java-home
JAVA_VERSION=8u141
JAVA_DEBIAN_VERSION=8u141-b15-1~deb9u1
CA_CERTIFICATES_JAVA_VERSION=20170531+nmu1
MAVEN_HOME=/usr/share/maven
MAVEN_CONFIG=/root/.m2
HOME=/root

```