### PR TITLE
Java 11 support

### DIFF
--- a/java-runtime-builder-app/pom.xml
+++ b/java-runtime-builder-app/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.7.1</version>
+      <version>2.23.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -82,14 +82,14 @@
           <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-compiler-javac-errorprone</artifactId>
-            <version>2.8</version>
+            <version>2.8.5</version>
           </dependency>
           <!-- override plexus-compiler-javac-errorprone's dependency on
                Error Prone with the latest version -->
           <dependency>
             <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_core</artifactId>
-            <version>2.0.19</version>
+            <version>2.3.3</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.7.7.201606060606</version>
+        <version>0.8.3</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
This is work towards Java 11 support now that Java 8 is reaching the end of non-commercial support, and therefore Java 11 is commonly the default.