### PR TITLE
Update Travis to build using OpenJDK 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ services:
 
 jdk:
   - oraclejdk8
+  - oraclejdk11
 
 script: mvn --batch-mode clean package
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ services:
 
 jdk:
   - oraclejdk8
-  - oraclejdk11
+  - openjdk10
 
 script: mvn --batch-mode clean package
 

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.0</version>
         <configuration>
           <useSystemClassLoader>false</useSystemClassLoader>
         </configuration>


### PR DESCRIPTION
This PR covers a passing build for OpenJDK 10 which allows those on Ubuntu 18.04 LTS with the bundled JDK to proceed without issue.

The [failing build](https://travis-ci.org/GoogleCloudPlatform/runtime-builder-java/jobs/509129472) with Oracle JDK 11 is due to the compiler rejecting the JDK classes being version 55.

